### PR TITLE
Deprecate support for Goerli

### DIFF
--- a/demos/taco-nft-demo/src/NFTConditionBuilder.tsx
+++ b/demos/taco-nft-demo/src/NFTConditionBuilder.tsx
@@ -1,5 +1,5 @@
 import { conditions } from '@nucypher/taco';
-import { useEthers } from '@usedapp/core';
+import { Sepolia, useEthers} from '@usedapp/core';
 import React, { useState } from 'react';
 
 interface Props {
@@ -14,10 +14,10 @@ export const NFTConditionBuilder = ({
   enabled,
 }: Props) => {
   const { library } = useEthers();
-  const goerliNFTAddress = '0x932Ca55B9Ef0b3094E8Fa82435b3b4c50d713043'; // https://goerli-nfts.vercel.app/
-  const [contractAddress, setContractAddress] = useState(goerliNFTAddress);
+  const nftAddress = '0x0'; // Create a new NFT here https://nfts2me.com/create/generative/
+  const [contractAddress, setContractAddress] = useState(nftAddress);
   const [tokenId, setTokenId] = useState('');
-  const [chain, setChain] = useState(5);
+  const [chain, setChain] = useState(Sepolia.chainId);
 
   if (!enabled || !library) {
     return <></>;
@@ -45,9 +45,9 @@ export const NFTConditionBuilder = ({
     />
   );
 
-  const contractAddressInput = makeInput(setContractAddress, goerliNFTAddress);
+  const contractAddressInput = makeInput(setContractAddress, nftAddress);
   const tokenIdInput = makeInput(setTokenId);
-  const chainInput = makeChainInput(setChain, 5);
+  const chainInput = makeChainInput(setChain, Sepolia.chainId);
 
   const makeCondition = (): conditions.condition.Condition => {
     if (tokenId) {
@@ -97,7 +97,7 @@ export const NFTConditionBuilder = ({
           <div>
             <p>
               You can mint an NFT{' '}
-              <a href="https://goerli-nfts.vercel.app/">here</a> or use your own
+              <a href="https://nfts2me.com/create/generative/">here</a> or use your own
               contract.
             </p>
           </div>

--- a/packages/shared/src/web3.ts
+++ b/packages/shared/src/web3.ts
@@ -3,7 +3,6 @@ import { fromHexString } from './utils';
 export enum ChainId {
   POLYGON = 137,
   MUMBAI = 80001,
-  GOERLI = 5,
   SEPOLIA = 11155111,
   ETHEREUM_MAINNET = 1,
 }

--- a/packages/taco/examples/conditions.ts
+++ b/packages/taco/examples/conditions.ts
@@ -1,15 +1,16 @@
+import { ChainId } from '@nucypher/shared';
 import { conditions } from '../src';
 
 const ownsNFT = new conditions.predefined.erc721.ERC721Ownership({
   contractAddress: '0x1e988ba4692e52Bc50b375bcC8585b95c48AaD77',
   parameters: [3591],
-  chain: 5,
+  chain: ChainId.SEPOLIA,
 });
 console.assert(ownsNFT.requiresSigner(), 'ERC721Ownership requires signer');
 
 const hasAtLeastTwoNFTs = new conditions.predefined.erc721.ERC721Balance({
   contractAddress: '0x1e988ba4692e52Bc50b375bcC8585b95c48AaD77',
-  chain: 5,
+  chain: ChainId.SEPOLIA,
   returnValueTest: {
     comparator: '>=',
     value: 2,
@@ -27,7 +28,7 @@ const ownsNFTRaw = new conditions.base.contract.ContractCondition({
   standardContractType: 'ERC721',
   // User-provided
   contractAddress: '0x1e988ba4692e52Bc50b375bcC8585b95c48AaD77',
-  chain: 5,
+  chain: ChainId.SEPOLIA,
   returnValueTest: {
     comparator: '>',
     value: 0,
@@ -39,7 +40,7 @@ console.assert(
 );
 
 const hasAnyNativeAsset = new conditions.base.rpc.RpcCondition({
-  chain: 5,
+  chain: ChainId.SEPOLIA,
   method: 'eth_getBalance',
   parameters: [':userAddress'],
   returnValueTest: {
@@ -55,7 +56,7 @@ console.assert(
 const ownsNFTOnChain5 = new conditions.predefined.erc721.ERC721Ownership({
   contractAddress: '0x1e988ba4692e52Bc50b375bcC8585b95c48AaD77',
   parameters: [3591],
-  chain: 5, // The first network we target
+  chain: ChainId.SEPOLIA, // The first network we target
 });
 
 const hasAnyNativeAssetOnChain1 = new conditions.base.rpc.RpcCondition({
@@ -108,7 +109,7 @@ const myContractCallCondition = new conditions.base.contract.ContractCondition({
   parameters: [':userAddress', ':myCustomParam'], // `myMethodAbi.inputs`
   functionAbi: myFunctionAbi,
   contractAddress: '0x0...1',
-  chain: 5,
+  chain: ChainId.SEPOLIA,
   returnValueTest: {
     comparator: '>',
     value: 0,

--- a/packages/taco/examples/context.ts
+++ b/packages/taco/examples/context.ts
@@ -1,3 +1,4 @@
+import { ChainId } from '@nucypher/shared';
 import { conditions } from '../src';
 import { CustomContextParam } from '../src/conditions/context';
 
@@ -6,7 +7,7 @@ const ownsNFTRaw = new conditions.base.contract.ContractCondition({
   parameters: [':userAddress'],
   standardContractType: 'ERC721',
   contractAddress: '0x1e988ba4692e52Bc50b375bcC8585b95c48AaD77',
-  chain: 5,
+  chain: ChainId.SEPOLIA,
   returnValueTest: {
     comparator: '>',
     value: ':selectedBalance',

--- a/packages/taco/examples/encrypt-decrypt.ts
+++ b/packages/taco/examples/encrypt-decrypt.ts
@@ -1,5 +1,6 @@
 import { ethers } from 'ethers';
 
+import { ChainId } from '@nucypher/shared';
 import {
   conditions,
   decrypt,
@@ -24,7 +25,7 @@ const run = async () => {
     const ownsNFT = new conditions.predefined.erc721.ERC721Ownership({
       contractAddress: '0x1e988ba4692e52Bc50b375bcC8585b95c48AaD77',
       parameters: [3591],
-      chain: 5,
+      chain: ChainId.SEPOLIA,
     });
     const messageKit = await encrypt(
       web3Provider,

--- a/packages/taco/src/conditions/const.ts
+++ b/packages/taco/src/conditions/const.ts
@@ -12,7 +12,6 @@ export const CONTEXT_PARAM_PREFIX = ':';
 export const SUPPORTED_CHAIN_IDS = [
   ChainId.POLYGON,
   ChainId.MUMBAI,
-  ChainId.GOERLI,
   ChainId.SEPOLIA,
   ChainId.ETHEREUM_MAINNET,
 ];

--- a/packages/taco/test/conditions/base/condition.test.ts
+++ b/packages/taco/test/conditions/base/condition.test.ts
@@ -43,7 +43,6 @@ describe('validation', () => {
         _errors: [
           'Invalid literal value, expected 137',
           'Invalid literal value, expected 80001',
-          'Invalid literal value, expected 5',
           'Invalid literal value, expected 11155111',
           'Invalid literal value, expected 1',
         ],

--- a/packages/taco/test/conditions/base/time.test.ts
+++ b/packages/taco/test/conditions/base/time.test.ts
@@ -1,3 +1,5 @@
+import { ChainId } from '@nucypher/shared';
+import { TEST_CHAIN_ID } from '@nucypher/test-utils';
 import { describe, expect, it } from 'vitest';
 
 import {
@@ -20,7 +22,7 @@ describe('validation', () => {
       conditionType: TimeConditionType,
       returnValueTest,
       method: TimeConditionMethod,
-      chain: 1,
+      chain: ChainId.ETHEREUM_MAINNET,
     };
     const result = TimeCondition.validate(timeConditionSchema, conditionObj);
 
@@ -36,7 +38,7 @@ describe('validation', () => {
         ...returnValueTest,
         comparator: 'not-a-comparator',
       },
-      chain: 5,
+      chain: TEST_CHAIN_ID,
     } as unknown as TimeConditionProps;
     const result = TimeCondition.validate(timeConditionSchema, badObj);
 
@@ -57,7 +59,7 @@ describe('validation', () => {
     const condition = new TimeCondition({
       returnValueTest,
       method: TimeConditionMethod,
-      chain: 5,
+      chain: TEST_CHAIN_ID,
     });
     expect(condition.value.conditionType).toEqual(TimeConditionType);
   });
@@ -66,7 +68,7 @@ describe('validation', () => {
     const badObj = {
       ...returnValueTest,
       method: 'non-existing-method',
-      chain: 5,
+      chain: TEST_CHAIN_ID,
     } as unknown as TimeConditionProps;
     const result = TimeCondition.validate(timeConditionSchema, badObj);
 

--- a/packages/taco/test/conditions/compound-condition.test.ts
+++ b/packages/taco/test/conditions/compound-condition.test.ts
@@ -8,6 +8,7 @@ import {
   compoundConditionSchema,
   CompoundConditionType,
 } from '../../src/conditions/compound-condition';
+import { SUPPORTED_CHAIN_IDS } from '../../src/conditions/const';
 import {
   testContractConditionObj,
   testRpcConditionObj,
@@ -134,7 +135,7 @@ describe('validation', () => {
   const multichainCondition: CompoundConditionProps = {
     conditionType: CompoundConditionType,
     operator: 'and',
-    operands: [1, 137, 5, 80001].map((chain) => ({
+    operands: SUPPORTED_CHAIN_IDS.map((chain) => ({
       ...testRpcConditionObj,
       chain,
     })),

--- a/packages/taco/test/conditions/conditions.test.ts
+++ b/packages/taco/test/conditions/conditions.test.ts
@@ -14,7 +14,7 @@ describe('conditions', () => {
 
   it('creates a complex condition with custom parameters', async () => {
     const hasPositiveBalance = {
-      chain: 80001,
+      chain: ChainId.MUMBAI,
       method: 'eth_getBalance',
       parameters: [':userAddress', 'latest'],
       returnValueTest: {
@@ -23,7 +23,7 @@ describe('conditions', () => {
       },
     };
     const timeIsGreaterThan = {
-      chain: 5,
+      chain: ChainId.SEPOLIA,
       method: 'blocktime',
       returnValueTest: {
         comparator: '>',

--- a/packages/taco/test/taco.test.ts
+++ b/packages/taco/test/taco.test.ts
@@ -12,6 +12,7 @@ import {
   fakeTDecFlow,
   mockGetRitualIdFromPublicKey,
   mockTacoDecrypt,
+  TEST_CHAIN_ID,
 } from '@nucypher/test-utils';
 import { beforeAll, describe, expect, it } from 'vitest';
 
@@ -31,7 +32,7 @@ const message = 'this is a secret';
 const ownsNFT = new conditions.predefined.erc721.ERC721Ownership({
   contractAddress: '0x1e988ba4692e52Bc50b375bcC8585b95c48AaD77',
   parameters: [3591],
-  chain: 5,
+  chain: TEST_CHAIN_ID,
 });
 
 describe('taco', () => {

--- a/packages/taco/test/test-utils.ts
+++ b/packages/taco/test/test-utils.ts
@@ -219,7 +219,7 @@ export const testTimeConditionObj: TimeConditionProps = {
     value: 100,
   },
   method: TimeConditionMethod,
-  chain: 5,
+  chain: TEST_CHAIN_ID,
 };
 
 export const testRpcConditionObj: RpcConditionProps = {
@@ -233,7 +233,7 @@ export const testRpcConditionObj: RpcConditionProps = {
 export const testContractConditionObj: ContractConditionProps = {
   conditionType: ContractConditionType,
   contractAddress: '0x0000000000000000000000000000000000000000',
-  chain: 5,
+  chain: TEST_CHAIN_ID,
   standardContractType: 'ERC20',
   method: 'balanceOf',
   parameters: ['0x1e988ba4692e52Bc50b375bcC8585b95c48AaD77'],

--- a/packages/test-utils/src/variables.ts
+++ b/packages/test-utils/src/variables.ts
@@ -1,3 +1,5 @@
+import { ChainId } from '@nucypher/shared';
+
 export const aliceSecretKeyBytes = new Uint8Array([
   55, 82, 190, 189, 203, 164, 60, 148, 36, 86, 46, 123, 63, 152, 215, 113, 174,
   86, 244, 44, 23, 227, 197, 68, 5, 85, 116, 31, 208, 152, 88, 53,
@@ -11,4 +13,4 @@ export const bobSecretKeyBytes = new Uint8Array([
 export const TEST_CONTRACT_ADDR = '0x0000000000000000000000000000000000000001';
 export const TEST_CONTRACT_ADDR_2 =
   '0x0000000000000000000000000000000000000002';
-export const TEST_CHAIN_ID = 5;
+export const TEST_CHAIN_ID = ChainId.SEPOLIA;

--- a/packages/test-utils/tsconfig.json
+++ b/packages/test-utils/tsconfig.json
@@ -4,5 +4,10 @@
   "compilerOptions": {
     "esModuleInterop": true,
     "skipLibCheck": true,
-  }
+  },
+  "references": [
+    {
+      "path": "../shared/tsconfig.es.json"
+    }
+  ]
 }


### PR DESCRIPTION
**Type of PR:**
- Feature

**Required reviews:**
- 1

**Issues fixed/closed:**
- Refers to: https://github.com/nucypher/tdec/issues/139

**Why is it needed:**
- Goerli is entering [end-of-life on January 2024](https://ethereum-magicians.org/t/proposal-predictable-ethereum-testnet-lifecycle/11575)