### PR TITLE
refactor: taco nodejs example

### DIFF
--- a/packages/taco/src/conditions/base/shared.ts
+++ b/packages/taco/src/conditions/base/shared.ts
@@ -19,11 +19,7 @@ export const plainStringSchema = z.string().refine(
   },
 );
 
-const paramSchema = z.union([
-  plainStringSchema,
-  z.boolean(),
-  z.number(),
-]);
+const paramSchema = z.union([plainStringSchema, z.boolean(), z.number()]);
 
 export const paramOrContextParamSchema: z.ZodSchema = z.union([
   paramSchema,

--- a/packages/taco/test/conditions/context.test.ts
+++ b/packages/taco/test/conditions/context.test.ts
@@ -6,7 +6,8 @@ import { beforeAll, describe, expect, it } from 'vitest';
 import { toBytes, toHexString } from '../../src';
 import {
   ConditionExpression,
-  ContractCondition, ContractConditionProps,
+  ContractCondition,
+  ContractConditionProps,
   CustomContextParam,
   ReturnValueTestProps,
   RpcCondition,
@@ -336,8 +337,7 @@ describe('param or context param schema', () => {
           ':slim_shady',
           false,
         ],
-      ])
-        .success,
+      ]).success,
     ).toBe(true);
   });
 
@@ -375,7 +375,6 @@ describe('param or context param schema', () => {
   });
 
   it('rejects a function', () => {
-    expect(paramOrContextParamSchema.safeParse(() => {}).success,
-    ).toBe(false);
+    expect(paramOrContextParamSchema.safeParse(() => {}).success).toBe(false);
   });
 });


### PR DESCRIPTION
**Type of PR:**

- Documentation

**Required reviews:**

- 1

**What this does:**
Adds a more clear and understandable example code for Taco by separating the encrypt and decrypt functions

**Why it's needed:**
It was not clear in the example how to create an encrypted message, send it somewhere else, and decrypt it later. The decryption code parts were using objects from encryption. So I separated encrypt and decrypt functions to show the users how they can be separately used.