### PR TITLE
Add a `tapir` CI job

### DIFF
--- a/.github/workflows/tapir.yml
+++ b/.github/workflows/tapir.yml
@@ -1,9 +1,11 @@
-name: '🔎 Lynx Testnet Example'
+name: '🔎 Tapir Testnet Example'
 
 on:
   schedule:
     - cron: "0 * * * *"  # Every hour
   pull_request:
+    branches:
+      - main
   workflow_dispatch:
 
 # TODO: Use variables when GH supports it for forks. See https://github.com/orgs/community/discussions/44322
@@ -11,11 +13,11 @@ env:
   RPC_PROVIDER_URL: "https://polygon-mumbai.infura.io/v3/3747007a284045d483c342fb39889a30"
   ENCRYPTOR_PRIVATE_KEY: "0x900edb9e8214b2353f82aa195e915128f419a92cfb8bbc0f4784f10ef4112b86"
   CONSUMER_PRIVATE_KEY: "0xf307e165339cb5deb2b8ec59c31a5c0a957b8e8453ce7fe8a19d9a4c8acf36d4"
-  RITUAL_ID: "0"
+  RITUAL_ID: "5"
 
 jobs:
   networks:
-    name: '🔎 Lynx Testnet Example on Node ${{ matrix.node }} and ${{ matrix.os }}'
+    name: '🔎 Tapir Testnet Example on Node ${{ matrix.node }} and ${{ matrix.os }}'
 
     runs-on: ${{ matrix.os }}
     strategy:
@@ -47,7 +49,7 @@ jobs:
           echo ENCRYPTOR_PRIVATE_KEY=$ENCRYPTOR_PRIVATE_KEY >> .env
           echo CONSUMER_PRIVATE_KEY=$CONSUMER_PRIVATE_KEY >> .env
           echo RITUAL_ID=$RITUAL_ID >> .env
-          echo DOMAIN=lynx >> .env
+          echo DOMAIN=tapir >> .env
 
       - name: Run taco/nodejs script
         working-directory: ./examples/taco/nodejs

--- a/demos/taco-demo/src/config.ts
+++ b/demos/taco-demo/src/config.ts
@@ -4,4 +4,4 @@ export const DEFAULT_RITUAL_ID =
   (process.env.DEFAULT_RITUAL_ID && parseInt(process.env.DEFAULT_RITUAL_ID)) ||
   24;
 
-export const DEFAULT_DOMAIN = process.env.DEFAULT_DOMAIN || domains.DEV;
+export const DEFAULT_DOMAIN = process.env.DEFAULT_DOMAIN || domains.DEVNET;

--- a/demos/taco-nft-demo/src/config.ts
+++ b/demos/taco-nft-demo/src/config.ts
@@ -4,4 +4,4 @@ export const DEFAULT_RITUAL_ID =
   (process.env.DEFAULT_RITUAL_ID && parseInt(process.env.DEFAULT_RITUAL_ID)) ||
   24;
 
-export const DEFAULT_DOMAIN = process.env.DEFAULT_DOMAIN || domains.DEV;
+export const DEFAULT_DOMAIN = process.env.DEFAULT_DOMAIN || domains.DEVNET;

--- a/examples/taco/nodejs/.env.example
+++ b/examples/taco/nodejs/.env.example
@@ -5,3 +5,5 @@ RPC_PROVIDER_URL=https://polygon-mumbai-bor.publicnode.com
 # We provide here some defaults, but we encourage you to choose your own.
 ENCRYPTOR_PRIVATE_KEY=0x900edb9e8214b2353f82aa195e915128f419a92cfb8bbc0f4784f10ef4112b86
 CONSUMER_PRIVATE_KEY=0xf307e165339cb5deb2b8ec59c31a5c0a957b8e8453ce7fe8a19d9a4c8acf36d4
+RITUAL_ID=5
+DOMAIN=tapir

--- a/examples/taco/nodejs/src/index.ts
+++ b/examples/taco/nodejs/src/index.ts
@@ -32,9 +32,12 @@ if (!consumerPrivateKey) {
   throw new Error('CONSUMER_PRIVATE_KEY is not set.');
 }
 
-const domain = domains.DEVNET;
-const ritualId = 0; // Replace with your own ritual ID
+const domain = process.env.DOMAIN || domains.TESTNET;
+const ritualId = parseInt(process.env.RITUAL_ID || "5");
 const provider = new ethers.providers.JsonRpcProvider(rpcProviderUrl);
+
+console.log('Domain:', domain);
+console.log('Ritual ID:', ritualId);
 
 const encryptToBytes = async (messageString: string) => {
   const encryptorSigner = new ethers.Wallet(encryptorPrivateKey);

--- a/examples/taco/nodejs/src/index.ts
+++ b/examples/taco/nodejs/src/index.ts
@@ -32,8 +32,8 @@ if (!consumerPrivateKey) {
   throw new Error('CONSUMER_PRIVATE_KEY is not set.');
 }
 
-const domain = domains.TESTNET;
-const ritualId = 5; // Replace with your own ritual ID
+const domain = domains.DEVNET;
+const ritualId = 0; // Replace with your own ritual ID
 const provider = new ethers.providers.JsonRpcProvider(rpcProviderUrl);
 
 const encryptToBytes = async (messageString: string) => {

--- a/packages/pre/test/acceptance/alice-grants.test.ts
+++ b/packages/pre/test/acceptance/alice-grants.test.ts
@@ -73,7 +73,7 @@ describe('story: alice shares message with bob through policy', () => {
     policy = await alice.grant(
       fakeProvider(),
       fakeSigner(),
-      domains.DEV,
+      domains.DEVNET,
       fakePorterUri,
       policyParams,
     );

--- a/packages/pre/test/acceptance/delay-enact.test.ts
+++ b/packages/pre/test/acceptance/delay-enact.test.ts
@@ -62,7 +62,7 @@ describe('story: alice creates a policy but someone else enacts it', () => {
       const enacted = await preEnactedPolicy.enact(
         provider,
         fakeSigner(),
-        domains.DEV,
+        domains.DEVNET,
       );
       expect(enacted.txHash).toBeDefined();
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "@ethersproject/abi": "^5.7.0",
     "@ethersproject/providers": "^5.7.2",
-    "@nucypher/nucypher-contracts": "^0.13.0",
+    "@nucypher/nucypher-contracts": "^0.15.0",
     "@nucypher/nucypher-core": "*",
     "axios": "^1.6.2",
     "deep-equal": "^2.2.3",

--- a/packages/shared/src/porter.ts
+++ b/packages/shared/src/porter.ts
@@ -22,7 +22,7 @@ const porterUri: Record<string, string> = {
 export type Domain = keyof typeof porterUri;
 
 export const domains: Record<string, Domain> = {
-  DEV: 'lynx',
+  DEVNET: 'lynx',
   TESTNET: 'tapir',
   MAINNET: 'mainnet',
 };

--- a/packages/taco/test/taco.test.ts
+++ b/packages/taco/test/taco.test.ts
@@ -48,7 +48,7 @@ describe('taco', () => {
 
     const messageKit = await taco.encrypt(
       provider,
-      domains.DEV,
+      domains.DEVNET,
       message,
       ownsNFT,
       mockedDkg.ritualId,
@@ -81,7 +81,7 @@ describe('taco', () => {
 
     const decryptedMessage = await taco.decrypt(
       provider,
-      domains.DEV,
+      domains.DEVNET,
       messageKit,
       fakePorterUri,
       signer,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -486,8 +486,8 @@ importers:
         specifier: ^5.7.2
         version: 5.7.2
       '@nucypher/nucypher-contracts':
-        specifier: ^0.13.0
-        version: 0.13.0
+        specifier: ^0.15.0
+        version: 0.15.0
       '@nucypher/nucypher-core':
         specifier: 0.13.0-alpha.1
         version: 0.13.0-alpha.1
@@ -3593,8 +3593,8 @@ packages:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.15.0
 
-  /@nucypher/nucypher-contracts@0.13.0:
-    resolution: {integrity: sha512-QB9vCVq2mLR2SeA/gSX8Px2QW3wcc9keQuTwgtDOA5J7PLoxDHEAko4ow6ZlsfjsbK572Xz6YReH09MBr71ujA==}
+  /@nucypher/nucypher-contracts@0.15.0:
+    resolution: {integrity: sha512-AVAAJfCdymvaIPnT2fGCL096fNhw70a9OaHGgr6oTMqOeXmyl/ojHHW6FfFOcTToWVsnA5000dTbLe0lfFhrOg==}
     dev: false
 
   /@nucypher/nucypher-core@0.13.0-alpha.1:


### PR DESCRIPTION
**Type of PR:**

- Other

**Required reviews:**
- 1

**What this does:**
- Adds `.env` based config for `domain` and `ritualId` in the nodejs `taco` example
- Adds a CI job for `tapir` testnet 
- Renames `domain.DEV` to `domain.DEVNET` for consistency