### PR TITLE
Update `tapir` ritual

### DIFF
--- a/.github/workflows/tapir.yml
+++ b/.github/workflows/tapir.yml
@@ -10,10 +10,10 @@ on:
 
 # TODO: Use variables when GH supports it for forks. See https://github.com/orgs/community/discussions/44322
 env:
-  RPC_PROVIDER_URL: "https://polygon-mumbai.infura.io/v3/3747007a284045d483c342fb39889a30"
+  RPC_PROVIDER_URL: "https://polygon-mumbai-bor.publicnode.com"
   ENCRYPTOR_PRIVATE_KEY: "0x900edb9e8214b2353f82aa195e915128f419a92cfb8bbc0f4784f10ef4112b86"
   CONSUMER_PRIVATE_KEY: "0xf307e165339cb5deb2b8ec59c31a5c0a957b8e8453ce7fe8a19d9a4c8acf36d4"
-  RITUAL_ID: "5"
+  RITUAL_ID: "0"
 
 jobs:
   networks:

--- a/demos/taco-demo/src/config.ts
+++ b/demos/taco-demo/src/config.ts
@@ -1,4 +1,4 @@
 import { domains } from '@nucypher/taco';
 
-export const DEFAULT_RITUAL_ID = parseInt(process.env.DEFAULT_RITUAL_ID || '5');
+export const DEFAULT_RITUAL_ID = parseInt(process.env.DEFAULT_RITUAL_ID || '0');
 export const DEFAULT_DOMAIN = process.env.DEFAULT_DOMAIN || domains.TESTNET;

--- a/demos/taco-nft-demo/src/config.ts
+++ b/demos/taco-nft-demo/src/config.ts
@@ -1,4 +1,4 @@
 import { domains } from '@nucypher/taco';
 
-export const DEFAULT_RITUAL_ID = parseInt(process.env.DEFAULT_RITUAL_ID || '5');
+export const DEFAULT_RITUAL_ID = parseInt(process.env.DEFAULT_RITUAL_ID || '0');
 export const DEFAULT_DOMAIN = process.env.DEFAULT_DOMAIN || domains.TESTNET;

--- a/examples/taco/nextjs/src/app/page.tsx
+++ b/examples/taco/nextjs/src/app/page.tsx
@@ -12,7 +12,7 @@ import useTaco from '../hooks/useTaco';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 declare const window: any;
 
-const ritualId = 5; // Replace with your own ritual ID
+const ritualId = 0; // Replace with your own ritual ID
 const domain = domains.TESTNET;
 
 function App() {

--- a/examples/taco/nodejs/.env.example
+++ b/examples/taco/nodejs/.env.example
@@ -5,5 +5,5 @@ RPC_PROVIDER_URL=https://polygon-mumbai-bor.publicnode.com
 # We provide here some defaults, but we encourage you to choose your own.
 ENCRYPTOR_PRIVATE_KEY=0x900edb9e8214b2353f82aa195e915128f419a92cfb8bbc0f4784f10ef4112b86
 CONSUMER_PRIVATE_KEY=0xf307e165339cb5deb2b8ec59c31a5c0a957b8e8453ce7fe8a19d9a4c8acf36d4
-RITUAL_ID=5
+RITUAL_ID=0
 DOMAIN=tapir

--- a/examples/taco/nodejs/src/index.ts
+++ b/examples/taco/nodejs/src/index.ts
@@ -33,7 +33,7 @@ if (!consumerPrivateKey) {
 }
 
 const domain = process.env.DOMAIN || domains.TESTNET;
-const ritualId = parseInt(process.env.RITUAL_ID || '5');
+const ritualId = parseInt(process.env.RITUAL_ID || '0');
 const provider = new ethers.providers.JsonRpcProvider(rpcProviderUrl);
 
 console.log('Domain:', domain);

--- a/examples/taco/react/src/App.tsx
+++ b/examples/taco/react/src/App.tsx
@@ -9,7 +9,7 @@ import useTaco from './hooks/useTaco';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 declare const window: any;
 
-const ritualId = 5; // Replace with your own ritual ID
+const ritualId = 0; // Replace with your own ritual ID
 const domain = domains.TESTNET;
 
 function App() {

--- a/examples/taco/webpack-5/src/index.ts
+++ b/examples/taco/webpack-5/src/index.ts
@@ -17,7 +17,7 @@ declare const window: any;
 const runExample = async () => {
   await initialize();
 
-  const ritualId = 5; // Replace with your own ritual ID
+  const ritualId = 0; // Replace with your own ritual ID
   const domain = domains.TESTNET;
 
   const provider = new ethers.providers.Web3Provider(window.ethereum!, 'any');

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "@ethersproject/abi": "^5.7.0",
     "@ethersproject/providers": "^5.7.2",
-    "@nucypher/nucypher-contracts": "^0.15.0",
+    "@nucypher/nucypher-contracts": "^0.16.0",
     "@nucypher/nucypher-core": "*",
     "axios": "^1.6.2",
     "deep-equal": "^2.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -486,8 +486,8 @@ importers:
         specifier: ^5.7.2
         version: 5.7.2
       '@nucypher/nucypher-contracts':
-        specifier: ^0.15.0
-        version: 0.15.0
+        specifier: ^0.16.0
+        version: 0.16.0
       '@nucypher/nucypher-core':
         specifier: 0.13.0-alpha.1
         version: 0.13.0-alpha.1
@@ -3606,8 +3606,8 @@ packages:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.16.0
 
-  /@nucypher/nucypher-contracts@0.15.0:
-    resolution: {integrity: sha512-AVAAJfCdymvaIPnT2fGCL096fNhw70a9OaHGgr6oTMqOeXmyl/ojHHW6FfFOcTToWVsnA5000dTbLe0lfFhrOg==}
+  /@nucypher/nucypher-contracts@0.16.0:
+    resolution: {integrity: sha512-kS2emMiYWXT63HHzS4MFimyOsw2W0XHw8NYrUFOvNuDWVGe33WAcrSND1iFTSm1wiGaMPT/zQhoaYw7Kg/s7qw==}
     dev: false
 
   /@nucypher/nucypher-core@0.13.0-alpha.1:


### PR DESCRIPTION
**Type of PR:**
- Other

**Required reviews:**
- 1

**What this does:**
- Updates `tapir` ritual to use id `0`
- Updates contract registry using new `@nucypher/nucypher-contracts:0.16.0` version
- There seems to be some issue with [Infura project settings](https://github.com/nucypher/taco-web/actions/runs/7492767616/job/20397015512?pr=462#step:7:22). It works fine on the `lynx` job, but fails on the `tapir` job. I updated `tapir` job to use a public RPC instead.
