### PR TITLE
Release `taco@0.2.x`

### DIFF
--- a/demos/taco-demo/package.json
+++ b/demos/taco-demo/package.json
@@ -12,8 +12,8 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@nucypher/taco": "^0.1.0",
-    "@nucypher/shared": "^0.1.0",
+    "@nucypher/taco": "^0.2.0",
+    "@nucypher/shared": "^0.2.0",
     "@usedapp/core": "^1.2.13",
     "buffer": "^6.0.3",
     "ethers": "^5.7.1",

--- a/demos/taco-demo/package.json
+++ b/demos/taco-demo/package.json
@@ -12,8 +12,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@nucypher/taco": "^0.2.0",
-    "@nucypher/shared": "^0.2.0",
+    "@nucypher/taco": "^0.2.2",
     "@usedapp/core": "^1.2.13",
     "buffer": "^6.0.3",
     "ethers": "^5.7.1",

--- a/demos/taco-nft-demo/package.json
+++ b/demos/taco-nft-demo/package.json
@@ -12,8 +12,8 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@nucypher/taco": "^0.1.0",
-    "@nucypher/shared": "^0.1.0",
+    "@nucypher/taco": "^0.2.0",
+    "@nucypher/shared": "^0.2.0",
     "@usedapp/core": "^1.2.13",
     "buffer": "^6.0.3",
     "ethers": "^5.7.1",

--- a/demos/taco-nft-demo/package.json
+++ b/demos/taco-nft-demo/package.json
@@ -12,8 +12,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@nucypher/taco": "^0.2.0",
-    "@nucypher/shared": "^0.2.0",
+    "@nucypher/taco": "^0.2.2",
     "@usedapp/core": "^1.2.13",
     "buffer": "^6.0.3",
     "ethers": "^5.7.1",

--- a/examples/taco/nodejs/src/index.ts
+++ b/examples/taco/nodejs/src/index.ts
@@ -1,6 +1,5 @@
 import { format } from 'node:util';
 
-import { ThresholdMessageKit } from '@nucypher/nucypher-core';
 import {
   conditions,
   decrypt,
@@ -9,6 +8,7 @@ import {
   fromBytes,
   getPorterUri,
   initialize,
+  ThresholdMessageKit,
   toBytes,
   toHexString,
 } from '@nucypher/taco';

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
       "node-forge@<1.3.0": ">=1.3.0",
       "glob-parent@<5.1.2": ">=5.1.2",
       "nth-check@<2.0.1": ">=2.0.1",
-      "@nucypher/nucypher-core": "0.13.0-alpha.1"
+      "@nucypher/nucypher-core": "^0.14.1"
     }
   }
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nucypher/shared",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "keywords": [
     "pre",
     "taco",

--- a/packages/taco/package.json
+++ b/packages/taco/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nucypher/taco",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "keywords": [
     "taco",
     "threshold",
@@ -41,7 +41,7 @@
   "dependencies": {
     "@ethersproject/abstract-signer": "^5.7.0",
     "@nucypher/nucypher-core": "*",
-    "@nucypher/shared": "^0.1.0",
+    "@nucypher/shared": "^0.2.0",
     "ethers": "^5.7.2",
     "semver": "^7.5.2",
     "zod": "^3.22.4"

--- a/packages/taco/package.json
+++ b/packages/taco/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nucypher/taco",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "keywords": [
     "taco",
     "threshold",

--- a/packages/taco/package.json
+++ b/packages/taco/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nucypher/taco",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "keywords": [
     "taco",
     "threshold",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
   node-forge@<1.3.0: '>=1.3.0'
   glob-parent@<5.1.2: '>=5.1.2'
   nth-check@<2.0.1: '>=2.0.1'
-  '@nucypher/nucypher-core': 0.13.0-alpha.1
+  '@nucypher/nucypher-core': ^0.14.1
 
 importers:
 
@@ -19,8 +19,8 @@ importers:
         specifier: ^2.26.2
         version: 2.27.1
       '@nucypher/nucypher-core':
-        specifier: 0.13.0-alpha.1
-        version: 0.13.0-alpha.1
+        specifier: ^0.14.1
+        version: 0.14.1
     devDependencies:
       '@skypack/package-check':
         specifier: ^0.2.2
@@ -464,8 +464,8 @@ importers:
   packages/pre:
     dependencies:
       '@nucypher/nucypher-core':
-        specifier: 0.13.0-alpha.1
-        version: 0.13.0-alpha.1
+        specifier: ^0.14.1
+        version: 0.14.1
       '@nucypher/shared':
         specifier: workspace:*
         version: link:../shared
@@ -489,8 +489,8 @@ importers:
         specifier: ^0.16.0
         version: 0.16.0
       '@nucypher/nucypher-core':
-        specifier: 0.13.0-alpha.1
-        version: 0.13.0-alpha.1
+        specifier: ^0.14.1
+        version: 0.14.1
       axios:
         specifier: ^1.6.2
         version: 1.6.5
@@ -532,8 +532,8 @@ importers:
         specifier: ^5.7.0
         version: 5.7.0
       '@nucypher/nucypher-core':
-        specifier: 0.13.0-alpha.1
-        version: 0.13.0-alpha.1
+        specifier: ^0.14.1
+        version: 0.14.1
       '@nucypher/shared':
         specifier: ^0.2.0
         version: link:../shared
@@ -557,8 +557,8 @@ importers:
   packages/test-utils:
     dependencies:
       '@nucypher/nucypher-core':
-        specifier: 0.13.0-alpha.1
-        version: 0.13.0-alpha.1
+        specifier: ^0.14.1
+        version: 0.14.1
       '@nucypher/shared':
         specifier: workspace:*
         version: link:../shared
@@ -3610,8 +3610,8 @@ packages:
     resolution: {integrity: sha512-kS2emMiYWXT63HHzS4MFimyOsw2W0XHw8NYrUFOvNuDWVGe33WAcrSND1iFTSm1wiGaMPT/zQhoaYw7Kg/s7qw==}
     dev: false
 
-  /@nucypher/nucypher-core@0.13.0-alpha.1:
-    resolution: {integrity: sha512-uKu/YLTZ6mqkQ2kaQMJs/USUiw9EYFtaZU6FaD8zAN8XKLpHYuYD13BDfU7idR1nZIKjL/E5xIoVJFV3Dx0x2w==}
+  /@nucypher/nucypher-core@0.14.1:
+    resolution: {integrity: sha512-V/yCrjgQ8VFAeWhx9xtU1N3B8boSRA3y6+wriyaEb6kpMb4Cit+mWNiwNz9Xw0qdUcOtsoYlwb41RoZJKNOEAQ==}
     dev: false
 
   /@pkgjs/parseargs@0.11.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,11 +107,11 @@ importers:
   demos/taco-demo:
     dependencies:
       '@nucypher/shared':
-        specifier: ^0.1.0
-        version: 0.1.0
+        specifier: ^0.2.0
+        version: link:../../packages/shared
       '@nucypher/taco':
-        specifier: ^0.1.0
-        version: 0.1.0(@nucypher/shared@0.1.0)
+        specifier: ^0.2.0
+        version: link:../../packages/taco
       '@usedapp/core':
         specifier: ^1.2.13
         version: 1.2.13(ethers@5.7.2)(react@18.2.0)
@@ -183,11 +183,11 @@ importers:
   demos/taco-nft-demo:
     dependencies:
       '@nucypher/shared':
-        specifier: ^0.1.0
-        version: 0.1.0
+        specifier: ^0.2.0
+        version: link:../../packages/shared
       '@nucypher/taco':
-        specifier: ^0.1.0
-        version: 0.1.0(@nucypher/shared@0.1.0)
+        specifier: ^0.2.0
+        version: link:../../packages/taco
       '@usedapp/core':
         specifier: ^1.2.13
         version: 1.2.13(ethers@5.7.2)(react@18.2.0)
@@ -3606,51 +3606,12 @@ packages:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.16.0
 
-  /@nucypher/nucypher-contracts@0.15.0:
-    resolution: {integrity: sha512-AVAAJfCdymvaIPnT2fGCL096fNhw70a9OaHGgr6oTMqOeXmyl/ojHHW6FfFOcTToWVsnA5000dTbLe0lfFhrOg==}
-    dev: false
-
   /@nucypher/nucypher-contracts@0.16.0:
     resolution: {integrity: sha512-kS2emMiYWXT63HHzS4MFimyOsw2W0XHw8NYrUFOvNuDWVGe33WAcrSND1iFTSm1wiGaMPT/zQhoaYw7Kg/s7qw==}
     dev: false
 
   /@nucypher/nucypher-core@0.13.0-alpha.1:
     resolution: {integrity: sha512-uKu/YLTZ6mqkQ2kaQMJs/USUiw9EYFtaZU6FaD8zAN8XKLpHYuYD13BDfU7idR1nZIKjL/E5xIoVJFV3Dx0x2w==}
-    dev: false
-
-  /@nucypher/shared@0.1.0:
-    resolution: {integrity: sha512-bdtAC9TF8gha/qiKhqhIcGjdzHDqur5SnWOyYSbuZcgafTpxzDlF+qh6Xt5r2pCEeeBZinw9HSCTFHJJkW7TNg==}
-    engines: {node: '>=18', pnpm: '>=8.0.0'}
-    dependencies:
-      '@ethersproject/abi': 5.7.0
-      '@ethersproject/providers': 5.7.2
-      '@nucypher/nucypher-contracts': 0.15.0
-      '@nucypher/nucypher-core': 0.13.0-alpha.1
-      axios: 1.6.5
-      deep-equal: 2.2.3
-      ethers: 5.7.2
-      qs: 6.11.2
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - utf-8-validate
-    dev: false
-
-  /@nucypher/taco@0.1.0(@nucypher/shared@0.1.0):
-    resolution: {integrity: sha512-aEjmbq5RgtIoBWPhk2VMTtOSE0uXUMKNWQi/Lu7Bm9TvchTIp70isF5kjPeTy6f5Jr7yC+t6bW0roPFQXxq+Ig==}
-    engines: {node: '>=18', pnpm: '>=8.0.0'}
-    peerDependencies:
-      '@nucypher/shared': workspace:*
-    dependencies:
-      '@ethersproject/abstract-signer': 5.7.0
-      '@nucypher/nucypher-core': 0.13.0-alpha.1
-      '@nucypher/shared': 0.1.0
-      ethers: 5.7.2
-      semver: 7.5.4
-      zod: 3.22.4
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
     dev: false
 
   /@pkgjs/parseargs@0.11.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,11 +106,8 @@ importers:
 
   demos/taco-demo:
     dependencies:
-      '@nucypher/shared':
-        specifier: ^0.2.0
-        version: link:../../packages/shared
       '@nucypher/taco':
-        specifier: ^0.2.0
+        specifier: ^0.2.2
         version: link:../../packages/taco
       '@usedapp/core':
         specifier: ^1.2.13
@@ -182,11 +179,8 @@ importers:
 
   demos/taco-nft-demo:
     dependencies:
-      '@nucypher/shared':
-        specifier: ^0.2.0
-        version: link:../../packages/shared
       '@nucypher/taco':
-        specifier: ^0.2.0
+        specifier: ^0.2.2
         version: link:../../packages/taco
       '@usedapp/core':
         specifier: ^1.2.13

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,10 +108,10 @@ importers:
     dependencies:
       '@nucypher/shared':
         specifier: ^0.1.0
-        version: link:../../packages/shared
+        version: 0.1.0
       '@nucypher/taco':
         specifier: ^0.1.0
-        version: link:../../packages/taco
+        version: 0.1.0(@nucypher/shared@0.1.0)
       '@usedapp/core':
         specifier: ^1.2.13
         version: 1.2.13(ethers@5.7.2)(react@18.2.0)
@@ -184,10 +184,10 @@ importers:
     dependencies:
       '@nucypher/shared':
         specifier: ^0.1.0
-        version: link:../../packages/shared
+        version: 0.1.0
       '@nucypher/taco':
         specifier: ^0.1.0
-        version: link:../../packages/taco
+        version: 0.1.0(@nucypher/shared@0.1.0)
       '@usedapp/core':
         specifier: ^1.2.13
         version: 1.2.13(ethers@5.7.2)(react@18.2.0)
@@ -535,7 +535,7 @@ importers:
         specifier: 0.13.0-alpha.1
         version: 0.13.0-alpha.1
       '@nucypher/shared':
-        specifier: ^0.1.0
+        specifier: ^0.2.0
         version: link:../shared
       ethers:
         specifier: ^5.7.2
@@ -3606,12 +3606,51 @@ packages:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.16.0
 
+  /@nucypher/nucypher-contracts@0.15.0:
+    resolution: {integrity: sha512-AVAAJfCdymvaIPnT2fGCL096fNhw70a9OaHGgr6oTMqOeXmyl/ojHHW6FfFOcTToWVsnA5000dTbLe0lfFhrOg==}
+    dev: false
+
   /@nucypher/nucypher-contracts@0.16.0:
     resolution: {integrity: sha512-kS2emMiYWXT63HHzS4MFimyOsw2W0XHw8NYrUFOvNuDWVGe33WAcrSND1iFTSm1wiGaMPT/zQhoaYw7Kg/s7qw==}
     dev: false
 
   /@nucypher/nucypher-core@0.13.0-alpha.1:
     resolution: {integrity: sha512-uKu/YLTZ6mqkQ2kaQMJs/USUiw9EYFtaZU6FaD8zAN8XKLpHYuYD13BDfU7idR1nZIKjL/E5xIoVJFV3Dx0x2w==}
+    dev: false
+
+  /@nucypher/shared@0.1.0:
+    resolution: {integrity: sha512-bdtAC9TF8gha/qiKhqhIcGjdzHDqur5SnWOyYSbuZcgafTpxzDlF+qh6Xt5r2pCEeeBZinw9HSCTFHJJkW7TNg==}
+    engines: {node: '>=18', pnpm: '>=8.0.0'}
+    dependencies:
+      '@ethersproject/abi': 5.7.0
+      '@ethersproject/providers': 5.7.2
+      '@nucypher/nucypher-contracts': 0.15.0
+      '@nucypher/nucypher-core': 0.13.0-alpha.1
+      axios: 1.6.5
+      deep-equal: 2.2.3
+      ethers: 5.7.2
+      qs: 6.11.2
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - utf-8-validate
+    dev: false
+
+  /@nucypher/taco@0.1.0(@nucypher/shared@0.1.0):
+    resolution: {integrity: sha512-aEjmbq5RgtIoBWPhk2VMTtOSE0uXUMKNWQi/Lu7Bm9TvchTIp70isF5kjPeTy6f5Jr7yC+t6bW0roPFQXxq+Ig==}
+    engines: {node: '>=18', pnpm: '>=8.0.0'}
+    peerDependencies:
+      '@nucypher/shared': workspace:*
+    dependencies:
+      '@ethersproject/abstract-signer': 5.7.0
+      '@nucypher/nucypher-core': 0.13.0-alpha.1
+      '@nucypher/shared': 0.1.0
+      ethers: 5.7.2
+      semver: 7.5.4
+      zod: 3.22.4
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
     dev: false
 
   /@pkgjs/parseargs@0.11.0:


### PR DESCRIPTION
**Type of PR:**
- Other

**Required reviews:**
- 1

**Why it's needed:**
- One of the underlying dependencies, `@nucypher/nucypher-contracts` was updated
- Necessary to keep `taco-web` working for `tapir` users
