### PR TITLE
Add  a `mainnet` test job to ci

### DIFF
--- a/.github/workflows/mainnet.yml
+++ b/.github/workflows/mainnet.yml
@@ -1,0 +1,56 @@
+name: '🔎 Mainnet Example'
+
+on:
+  schedule:
+    - cron: "0 * * * *"  # Every hour
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+# TODO: Use variables when GH supports it for forks. See https://github.com/orgs/community/discussions/44322
+env:
+  RPC_PROVIDER_URL: "https://mainnet.infura.io/v3/3747007a284045d483c342fb39889a30"
+  ENCRYPTOR_PRIVATE_KEY: ${{ secrets.MAINNET_ENCRYPTOR_PRIVATE_KEY }}
+  CONSUMER_PRIVATE_KEY: ${{ secrets.MAINNET_CONSUMER_PRIVATE_KEY }}
+  RITUAL_ID: "1"
+
+jobs:
+  networks:
+    name: '🔎 Mainnet Example on Node ${{ matrix.node }} and ${{ matrix.os }}'
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        node: [ '18.x' ]
+        os: [ ubuntu-latest ]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 8.1
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        working-directory: ./examples/taco/nodejs
+        run: pnpm install
+
+      - name: Setup environment
+        working-directory: ./examples/taco/nodejs
+        # TODO: Use variables when GH supports it for forks. See https://github.com/orgs/community/discussions/44322
+        run: |
+          echo RPC_PROVIDER_URL=$RPC_PROVIDER_URL > .env
+          echo ENCRYPTOR_PRIVATE_KEY=$ENCRYPTOR_PRIVATE_KEY >> .env
+          echo CONSUMER_PRIVATE_KEY=$CONSUMER_PRIVATE_KEY >> .env
+          echo RITUAL_ID=$RITUAL_ID >> .env
+          echo DOMAIN=mainnet >> .env
+
+      - name: Run taco/nodejs script
+        working-directory: ./examples/taco/nodejs
+        run: pnpm start


### PR DESCRIPTION
**Type of PR:**
-  Other

**Required reviews:**
- 1

**What this does:**
- Adds another cron job for testing TACo on `mainnet`, similar to existing `tapir` and `lynx` jobs

**Why it's needed:**
- We don't monitor compatibility of TACo and `mainnet` 

**Notes for reviewers:**
- The new `mainnet` job is failing because I've created this PR from my fork, where access to repository secrets is not possible