### PR TITLE
Add predefined `ERC20BalanceOf` condition

### DIFF
--- a/packages/taco/src/conditions/predefined/erc20.ts
+++ b/packages/taco/src/conditions/predefined/erc20.ts
@@ -1,0 +1,21 @@
+import {
+  ContractCondition,
+  ContractConditionProps,
+  ContractConditionType,
+} from '../base/contract';
+import { USER_ADDRESS_PARAM } from '../const';
+
+type ERC20BalanceFields = 'contractAddress' | 'chain' | 'returnValueTest';
+
+const ERC20BalanceDefaults: Omit<ContractConditionProps, ERC20BalanceFields> = {
+  conditionType: ContractConditionType,
+  method: 'balanceOf',
+  parameters: [USER_ADDRESS_PARAM],
+  standardContractType: 'ERC20',
+};
+
+export class ERC20Balance extends ContractCondition {
+  constructor(value: Pick<ContractConditionProps, ERC20BalanceFields>) {
+    super({ ...ERC20BalanceDefaults, ...value });
+  }
+}

--- a/packages/taco/src/conditions/predefined/index.ts
+++ b/packages/taco/src/conditions/predefined/index.ts
@@ -1,1 +1,2 @@
+export * as erc20 from './erc20';
 export * as erc721 from './erc721';

--- a/packages/taco/test/conditions/predefined/erc20.test.ts
+++ b/packages/taco/test/conditions/predefined/erc20.test.ts
@@ -1,0 +1,31 @@
+import { TEST_CHAIN_ID, TEST_CONTRACT_ADDR } from '@nucypher/test-utils';
+import { describe, expect, it } from 'vitest';
+
+import { ContractConditionProps } from '../../../src/conditions/base/contract';
+import { ERC20Balance } from '../../../src/conditions/predefined/erc20';
+
+describe('ERC20Balance', () => {
+  it('should create a valid ERC20Balance instance', () => {
+    const props: Pick<
+      ContractConditionProps,
+      'contractAddress' | 'chain' | 'returnValueTest'
+    > = {
+      contractAddress: TEST_CONTRACT_ADDR,
+      chain: TEST_CHAIN_ID,
+      returnValueTest: {
+        comparator: '==',
+        value: '10',
+      },
+    };
+
+    const instance = new ERC20Balance(props);
+    expect(instance).toBeInstanceOf(ERC20Balance);
+    expect(instance.toObj()).toEqual({
+      conditionType: 'contract',
+      method: 'balanceOf',
+      parameters: [':userAddress'],
+      standardContractType: 'ERC20',
+      ...props,
+    });
+  });
+});

--- a/packages/taco/test/conditions/predefined/erc721.test.ts
+++ b/packages/taco/test/conditions/predefined/erc721.test.ts
@@ -1,0 +1,61 @@
+import { TEST_CHAIN_ID, TEST_CONTRACT_ADDR } from '@nucypher/test-utils';
+import { describe, expect, it } from 'vitest';
+
+import { ContractConditionProps } from '../../../src/conditions/base/contract';
+import { USER_ADDRESS_PARAM } from '../../../src/conditions/const';
+import {
+  ERC721Balance,
+  ERC721Ownership,
+} from '../../../src/conditions/predefined/erc721';
+
+describe('ERC721Ownership', () => {
+  it('should create a valid ERC721Ownership instance', () => {
+    const props: Pick<
+      ContractConditionProps,
+      'contractAddress' | 'chain' | 'parameters'
+    > = {
+      contractAddress: TEST_CONTRACT_ADDR,
+      chain: TEST_CHAIN_ID,
+      parameters: [USER_ADDRESS_PARAM],
+    };
+
+    const instance = new ERC721Ownership(props);
+    expect(instance).toBeInstanceOf(ERC721Ownership);
+    expect(instance.toObj()).toEqual({
+      conditionType: 'contract',
+      method: 'ownerOf',
+      returnValueTest: {
+        comparator: '==',
+        value: ':userAddress',
+      },
+      standardContractType: 'ERC721',
+      ...props,
+    });
+  });
+});
+
+describe('ERC721Balance', () => {
+  it('should create a valid ERC721Balance instance', () => {
+    const props: Pick<
+      ContractConditionProps,
+      'contractAddress' | 'chain' | 'returnValueTest'
+    > = {
+      contractAddress: TEST_CONTRACT_ADDR,
+      chain: TEST_CHAIN_ID,
+      returnValueTest: {
+        comparator: '==',
+        value: '10',
+      },
+    };
+
+    const instance = new ERC721Balance(props);
+    expect(instance).toBeInstanceOf(ERC721Balance);
+    expect(instance.toObj()).toEqual({
+      conditionType: 'contract',
+      method: 'balanceOf',
+      parameters: [':userAddress'],
+      standardContractType: 'ERC721',
+      ...props,
+    });
+  });
+});


### PR DESCRIPTION
**Type of PR:**
- Feature

**Required reviews:**
- 1


**Notes for reviewers:**
- I think we already had this one at some point, but it must have been accidentally removed
- Also adds tests for `ERC721` predefined conditions
