### PR TITLE
Update `lynx` to use Polygon Amoy testnet

### DIFF
--- a/.github/workflows/lynx.yml
+++ b/.github/workflows/lynx.yml
@@ -8,10 +8,10 @@ on:
 
 # TODO: Use variables when GH supports it for forks. See https://github.com/orgs/community/discussions/44322
 env:
-  RPC_PROVIDER_URL: "https://polygon-mumbai.infura.io/v3/3747007a284045d483c342fb39889a30"
+  RPC_PROVIDER_URL: "https://rpc-amoy.polygon.technology"
   ENCRYPTOR_PRIVATE_KEY: "0x900edb9e8214b2353f82aa195e915128f419a92cfb8bbc0f4784f10ef4112b86"
   CONSUMER_PRIVATE_KEY: "0xf307e165339cb5deb2b8ec59c31a5c0a957b8e8453ce7fe8a19d9a4c8acf36d4"
-  RITUAL_ID: "5"
+  RITUAL_ID: "0"
 
 jobs:
   networks:

--- a/examples/taco/nodejs/src/index.ts
+++ b/examples/taco/nodejs/src/index.ts
@@ -49,8 +49,11 @@ const encryptToBytes = async (messageString: string) => {
   const message = toBytes(messageString);
   console.log(format('Encrypting message ("%s") ...', messageString));
 
+  // TODO: Remove after fixing #506
+  const chain = domain === 'lynx' ? 80002 : 80001;
+
   const hasPositiveBalance = new conditions.base.rpc.RpcCondition({
-    chain: 80002,
+    chain,
     method: 'eth_getBalance',
     parameters: [':userAddress', 'latest'],
     returnValueTest: {

--- a/examples/taco/nodejs/src/index.ts
+++ b/examples/taco/nodejs/src/index.ts
@@ -50,7 +50,7 @@ const encryptToBytes = async (messageString: string) => {
   console.log(format('Encrypting message ("%s") ...', messageString));
 
   const hasPositiveBalance = new conditions.base.rpc.RpcCondition({
-    chain: 80001,
+    chain: 80002,
     method: 'eth_getBalance',
     parameters: [':userAddress', 'latest'],
     returnValueTest: {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "@ethersproject/abi": "^5.7.0",
     "@ethersproject/providers": "^5.7.2",
-    "@nucypher/nucypher-contracts": "^0.20.0",
+    "@nucypher/nucypher-contracts": "file:../../../nucypher-contracts",
     "@nucypher/nucypher-core": "*",
     "axios": "^1.6.8",
     "deep-equal": "^2.2.3",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "@ethersproject/abi": "^5.7.0",
     "@ethersproject/providers": "^5.7.2",
-    "@nucypher/nucypher-contracts": "file:../../../nucypher-contracts",
+    "@nucypher/nucypher-contracts": "^0.21.0",
     "@nucypher/nucypher-core": "*",
     "axios": "^1.6.8",
     "deep-equal": "^2.2.3",

--- a/packages/shared/src/web3.ts
+++ b/packages/shared/src/web3.ts
@@ -2,7 +2,8 @@ import { fromHexString } from './utils';
 
 export enum ChainId {
   POLYGON = 137,
-  MUMBAI = 80001,
+  MUMBAI = 80001, // TODO(#506): Deprecate MUMBAI
+  AMOY = 80002,
   SEPOLIA = 11155111,
   ETHEREUM_MAINNET = 1,
 }

--- a/packages/taco/src/conditions/const.ts
+++ b/packages/taco/src/conditions/const.ts
@@ -11,7 +11,8 @@ export const CONTEXT_PARAM_PREFIX = ':';
 
 export const SUPPORTED_CHAIN_IDS = [
   ChainId.POLYGON,
-  ChainId.MUMBAI,
+  ChainId.MUMBAI, // TODO(#506): Deprecate MUMBAI
+  ChainId.AMOY,
   ChainId.SEPOLIA,
   ChainId.ETHEREUM_MAINNET,
 ];

--- a/packages/taco/test/conditions/base/condition.test.ts
+++ b/packages/taco/test/conditions/base/condition.test.ts
@@ -42,7 +42,8 @@ describe('validation', () => {
       chain: {
         _errors: [
           'Invalid literal value, expected 137',
-          'Invalid literal value, expected 80001',
+          'Invalid literal value, expected 80001', // TODO(#506): Deprecate MUMBAI
+          'Invalid literal value, expected 80002',
           'Invalid literal value, expected 11155111',
           'Invalid literal value, expected 1',
         ],

--- a/packages/taco/test/conditions/conditions.test.ts
+++ b/packages/taco/test/conditions/conditions.test.ts
@@ -14,7 +14,7 @@ describe('conditions', () => {
 
   it('creates a complex condition with custom parameters', async () => {
     const hasPositiveBalance = {
-      chain: ChainId.MUMBAI,
+      chain: ChainId.AMOY,
       method: 'eth_getBalance',
       parameters: [':userAddress', 'latest'],
       returnValueTest: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -480,8 +480,8 @@ importers:
         specifier: ^5.7.2
         version: 5.7.2
       '@nucypher/nucypher-contracts':
-        specifier: ^0.20.0
-        version: 0.20.0
+        specifier: file:../../../nucypher-contracts
+        version: file:../nucypher-contracts
       '@nucypher/nucypher-core':
         specifier: ^0.14.1
         version: 0.14.1
@@ -3599,10 +3599,6 @@ packages:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.16.0
-
-  /@nucypher/nucypher-contracts@0.20.0:
-    resolution: {integrity: sha512-v+Jcixp7gpKIh7mFWyeTgEy2bxjMLI3/bD/o88x9tTEeZuxD2mEfViUzfhtLuTatQRQLBFBvy+AFPd8re8L72A==}
-    dev: false
 
   /@nucypher/nucypher-core@0.14.1:
     resolution: {integrity: sha512-V/yCrjgQ8VFAeWhx9xtU1N3B8boSRA3y6+wriyaEb6kpMb4Cit+mWNiwNz9Xw0qdUcOtsoYlwb41RoZJKNOEAQ==}
@@ -15242,4 +15238,9 @@ packages:
 
   /zod@3.22.4:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
+    dev: false
+
+  file:../nucypher-contracts:
+    resolution: {directory: ../nucypher-contracts, type: directory}
+    name: '@nucypher/nucypher-contracts'
     dev: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -480,8 +480,8 @@ importers:
         specifier: ^5.7.2
         version: 5.7.2
       '@nucypher/nucypher-contracts':
-        specifier: file:../../../nucypher-contracts
-        version: file:../nucypher-contracts
+        specifier: ^0.21.0
+        version: 0.21.0
       '@nucypher/nucypher-core':
         specifier: ^0.14.1
         version: 0.14.1
@@ -3599,6 +3599,10 @@ packages:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.16.0
+
+  /@nucypher/nucypher-contracts@0.21.0:
+    resolution: {integrity: sha512-2ArdoHKNtPGJiTxhxlhhPrtg0YXPL/rbUy6EvtXVgw4Zwy4iJUw3n5calHcIzijyf4KZLc8wBdsGrCOpX5uC1A==}
+    dev: false
 
   /@nucypher/nucypher-core@0.14.1:
     resolution: {integrity: sha512-V/yCrjgQ8VFAeWhx9xtU1N3B8boSRA3y6+wriyaEb6kpMb4Cit+mWNiwNz9Xw0qdUcOtsoYlwb41RoZJKNOEAQ==}
@@ -15238,9 +15242,4 @@ packages:
 
   /zod@3.22.4:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
-    dev: false
-
-  file:../nucypher-contracts:
-    resolution: {directory: ../nucypher-contracts, type: directory}
-    name: '@nucypher/nucypher-contracts'
     dev: false


### PR DESCRIPTION
**Type of PR:**
- Feature


**Required reviews:**
- 1


**What this does:**
- Adds support for Amoy, chain id 80002
- Updates `taco-web` to use `nucypher-contracts@0.21.0`

**Why it's needed:**
- Mumbai is to be deprecated

**Notes for reviewers:**
- Related issue: #506 
- Related issue: https://github.com/nucypher/nucypher-contracts/pull/250