### PR TITLE
Remove instruction to add wallet to allow list

### DIFF
--- a/demos/taco-demo/src/App.tsx
+++ b/demos/taco-demo/src/App.tsx
@@ -123,8 +123,7 @@ export default function App() {
       </p>
       <p>
         Connect with us on our{' '}
-        <a href={'https://discord.gg/threshold'}>Discord server</a> at{' '}
-        <b>#taco</b> channel to get your wallet address allow-listed
+        <a href={'https://discord.gg/threshold'}>Discord server</a> for more info!
       </p>
 
       <h2>Ritual ID</h2>

--- a/demos/taco-demo/src/App.tsx
+++ b/demos/taco-demo/src/App.tsx
@@ -118,8 +118,10 @@ export default function App() {
 
       <h2>Notice</h2>
       <p>
-        In order to access this demo, make sure to allow-list your wallet
-        address first.
+        In production (mainnet domain), your wallet address (encryptor) will also have
+        to be allow-listed for this specific ritual. However, we have 
+        <a href={'https://docs.threshold.network/app-development/threshold-access-control-tac/integration-guide/get-started-with-tac#testnet-configuration'}>publicly available testnet rituals</a>
+        for use when developing your apps.
       </p>
       <p>
         Connect with us on our{' '}

--- a/demos/taco-nft-demo/src/App.tsx
+++ b/demos/taco-nft-demo/src/App.tsx
@@ -115,8 +115,7 @@ export default function App() {
       </p>
       <p>
         Connect with us on our{' '}
-        <a href={'https://discord.gg/threshold'}>Discord server</a> at{' '}
-        <b>#taco</b> channel to get your wallet address allow-listed
+        <a href={'https://discord.gg/threshold'}>Discord server</a> for more info!
       </p>
 
       <h2>Ritual ID</h2>

--- a/demos/taco-nft-demo/src/App.tsx
+++ b/demos/taco-nft-demo/src/App.tsx
@@ -110,8 +110,10 @@ export default function App() {
 
       <h2>Notice</h2>
       <p>
-        In order to access this demo, make sure to allow-list your wallet
-        address first.
+        In production (mainnet domain), your wallet address (encryptor) will also have
+        to be allow-listed for this specific ritual. However, we have 
+        <a href={'https://docs.threshold.network/app-development/threshold-access-control-tac/integration-guide/get-started-with-tac#testnet-configuration'}>publicly available testnet rituals</a>
+        for use when developing your apps.
       </p>
       <p>
         Connect with us on our{' '}


### PR DESCRIPTION
**Type of PR:**
- Documentation

We've had a couple of messages at hackathons where people ask to have their wallet added to allow list. This is no longer required because ritual id 0 is fully open
