### PR TITLE
Deprecate EIP712 authentication provider

### DIFF
--- a/packages/taco-auth/src/providers/eip712.ts
+++ b/packages/taco-auth/src/providers/eip712.ts
@@ -56,6 +56,9 @@ const EIP712Domain = [
   },
 ];
 
+/**
+ * @deprecated Use EIP4361AuthProvider instead.
+ */
 export class EIP712AuthProvider implements AuthProvider {
   private readonly storage: LocalStorage;
 
@@ -64,6 +67,10 @@ export class EIP712AuthProvider implements AuthProvider {
     private readonly provider: ethers.providers.Provider,
     private readonly signer: ethers.Signer,
   ) {
+    console.warn(
+      'DeprecationWarning: The EIP712AuthProvider authentication provider is deprecated. ' +
+      'Please use EIP4361AuthProvider instead. Refer to the documentation for more details.'
+    );
     this.storage = new LocalStorage();
   }
 

--- a/packages/taco-auth/src/types.ts
+++ b/packages/taco-auth/src/types.ts
@@ -19,6 +19,9 @@ export interface AuthSignature {
   typedData: EIP712TypedData | EIP4361TypedData;
 }
 
+/**
+ * @deprecated Use EIP4361_AUTH_METHOD instead.
+ */
 export const EIP712_AUTH_METHOD = 'EIP712';
 export const EIP4361_AUTH_METHOD = 'EIP4361';
 


### PR DESCRIPTION
**Type of PR:**
- Feature

**Required reviews:**
- 1

**What this does:**
- Marks `EIP712AuthProvider` as deprecated

**Issues fixed/closed:**
- Refers to https://github.com/nucypher/tdec/issues/178

**Notes for reviewers:**
- Should we outright remove EIP712 support instead of deprecating it? If not, what is a good timeline to allow `taco-web` users to adjust?
- Created https://github.com/nucypher/taco-web/issues/536
