### PR TITLE
Validate user-provided `AuthSignature`

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -47,7 +47,8 @@
     "axios": "^1.6.8",
     "deep-equal": "^2.2.3",
     "ethers": "*",
-    "qs": "^6.12.1"
+    "qs": "^6.12.1",
+    "zod": "*"
   },
   "devDependencies": {
     "@typechain/ethers-v5": "^11.1.2",

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -3,6 +3,7 @@ export * from './porter';
 export type * from './types';
 export * from './utils';
 export * from './web3';
+export * from './schemas';
 
 // Re-exports
 export {

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -1,0 +1,4 @@
+import { z } from 'zod';
+
+export const ETH_ADDRESS_REGEXP = new RegExp('^0x[a-fA-F0-9]{40}$');
+export const EthAddressSchema = z.string().regex(ETH_ADDRESS_REGEXP);

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -1,4 +1,16 @@
+import { ethers } from 'ethers';
 import { z } from 'zod';
 
 export const ETH_ADDRESS_REGEXP = new RegExp('^0x[a-fA-F0-9]{40}$');
-export const EthAddressSchema = z.string().regex(ETH_ADDRESS_REGEXP);
+
+const isAddress = (address: string) => {
+  try {
+    return ethers.utils.getAddress(address);
+  } catch {
+    return false;
+  }
+};
+
+export const EthAddressSchema = z.string()
+  .regex(ETH_ADDRESS_REGEXP)
+  .refine(isAddress, { message: 'Invalid Ethereum address' });

--- a/packages/shared/test/schemas.test.ts
+++ b/packages/shared/test/schemas.test.ts
@@ -1,0 +1,16 @@
+import {describe, expect, it} from 'vitest';
+
+import { EthAddressSchema } from '../src';
+
+
+describe('ethereum address schema', () => {
+  it('should accept valid ethereum address', () => {
+    const validAddress = '0x1234567890123456789012345678901234567890';
+    EthAddressSchema.parse(validAddress);
+  });
+
+  it('should reject invalid ethereum address', () => {
+    const invalidAddress = '0x123456789012345678901234567890123456789';
+    expect(() => EthAddressSchema.parse(invalidAddress)).toThrow();
+  });
+});

--- a/packages/taco-auth/package.json
+++ b/packages/taco-auth/package.json
@@ -41,7 +41,8 @@
   "dependencies": {
     "@ethersproject/abstract-signer": "^5.7.0",
     "@nucypher/shared": "workspace:*",
-    "siwe": "^2.3.2"
+    "siwe": "^2.3.2",
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@nucypher/test-utils": "workspace:*"

--- a/packages/taco-auth/src/auth-provider.ts
+++ b/packages/taco-auth/src/auth-provider.ts
@@ -1,5 +1,12 @@
-import {EIP4361AuthProvider, EIP4361TypedData} from './providers/eip4361';
-import {EIP712AuthProvider, EIP712TypedData} from './providers/eip712';
+import { AuthSignature } from './auth-sig';
+import { EIP4361AuthProvider, EIP712AuthProvider } from './providers';
+
+/**
+ * @deprecated Use EIP4361_AUTH_METHOD instead.
+ */
+export const EIP712_AUTH_METHOD = 'EIP712';
+export const EIP4361_AUTH_METHOD = 'EIP4361';
+
 
 export interface AuthProvider {
   getOrCreateAuthSignature(): Promise<AuthSignature>;
@@ -11,19 +18,6 @@ export type AuthProviders = {
   // Fallback to satisfy type checking
   [key: string]: AuthProvider | undefined;
 };
-
-export interface AuthSignature {
-  signature: string;
-  address: string;
-  scheme: 'EIP712' | 'EIP4361';
-  typedData: EIP712TypedData | EIP4361TypedData;
-}
-
-/**
- * @deprecated Use EIP4361_AUTH_METHOD instead.
- */
-export const EIP712_AUTH_METHOD = 'EIP712';
-export const EIP4361_AUTH_METHOD = 'EIP4361';
 
 export const USER_ADDRESS_PARAM_DEFAULT = ':userAddress';
 export const USER_ADDRESS_PARAM_EIP712 = `:userAddress${EIP712_AUTH_METHOD}`;

--- a/packages/taco-auth/src/auth-sig.ts
+++ b/packages/taco-auth/src/auth-sig.ts
@@ -1,0 +1,19 @@
+import { EthAddressSchema } from '@nucypher/shared';
+import { z } from 'zod';
+
+import { EIP4361_AUTH_METHOD, EIP712_AUTH_METHOD } from './auth-provider';
+import { EIP4361TypedDataSchema, EIP712TypedDataSchema } from './providers';
+
+
+export const authSignatureSchema = z.object({
+  signature: z.string(),
+  address: EthAddressSchema,
+  scheme: z.enum([EIP712_AUTH_METHOD, EIP4361_AUTH_METHOD]),
+  typedData: z.union([
+    EIP4361TypedDataSchema,
+    // TODO(#536): Remove post EIP712 deprecation
+    EIP712TypedDataSchema,
+  ]),
+});
+
+export type AuthSignature = z.infer<typeof authSignatureSchema>;

--- a/packages/taco-auth/src/helper.ts
+++ b/packages/taco-auth/src/helper.ts
@@ -1,16 +1,19 @@
-import {ethers} from "ethers";
+import { ethers } from 'ethers';
 
-import { EIP4361AuthProvider, EIP4361AuthProviderParams } from './providers/eip4361';
-import { EIP712AuthProvider } from './providers/eip712';
-import { AuthProviders, EIP4361_AUTH_METHOD, EIP712_AUTH_METHOD } from './types';
+import { AuthProviders, EIP4361_AUTH_METHOD, EIP712_AUTH_METHOD } from './auth-provider';
+import {
+  EIP4361AuthProvider,
+  EIP4361AuthProviderParams,
+  EIP712AuthProvider,
+} from './providers';
 
 export const makeAuthProviders = (
   provider: ethers.providers.Provider,
   signer?: ethers.Signer,
-  siweDefaultParams?: EIP4361AuthProviderParams
+  siweDefaultParams?: EIP4361AuthProviderParams,
 ): AuthProviders => {
   return {
     [EIP712_AUTH_METHOD]: signer ? new EIP712AuthProvider(provider, signer) : undefined,
-    [EIP4361_AUTH_METHOD]: signer ? new EIP4361AuthProvider(provider, signer, siweDefaultParams) : undefined
+    [EIP4361_AUTH_METHOD]: signer ? new EIP4361AuthProvider(provider, signer, siweDefaultParams) : undefined,
   } as AuthProviders;
 };

--- a/packages/taco-auth/src/index.ts
+++ b/packages/taco-auth/src/index.ts
@@ -1,4 +1,4 @@
-export * from './providers/eip4361';
-export * from './providers/eip712';
-export * from './types';
+export * from './providers';
 export * from './helper';
+export * from './auth-sig';
+export * from './auth-provider';

--- a/packages/taco-auth/src/providers/index.ts
+++ b/packages/taco-auth/src/providers/index.ts
@@ -1,25 +1,2 @@
-import { EIP4361_AUTH_METHOD, EIP712_AUTH_METHOD } from '../types';
-
-import { EIP4361AuthProvider, EIP4361TypedData } from './eip4361';
-import { EIP712AuthProvider, EIP712TypedData } from './eip712';
-
-export interface AuthSignatureProvider {
-  getOrCreateAuthSignature(): Promise<AuthSignature>;
-}
-
-export type AuthProviders = {
-  [EIP712_AUTH_METHOD]?: EIP712AuthProvider;
-  [EIP4361_AUTH_METHOD]?: EIP4361AuthProvider;
-  // Fallback to satisfy type checking
-  [key: string]: AuthProvider | undefined;
-};
-
-export interface AuthSignature {
-  signature: string;
-  address: string;
-  scheme: 'EIP712' | 'EIP4361';
-  typedData: EIP712TypedData | EIP4361TypedData;
-}
-
-// Add other providers here
-export type AuthProvider = AuthSignatureProvider;
+export * from './eip712';
+export * from './eip4361';

--- a/packages/taco-auth/src/storage.ts
+++ b/packages/taco-auth/src/storage.ts
@@ -1,3 +1,5 @@
+import { AuthSignature, authSignatureSchema } from './index';
+
 interface IStorage {
   getItem(key: string): string | null;
 
@@ -5,11 +7,11 @@ interface IStorage {
 }
 
 class BrowserStorage implements IStorage {
-  getItem(key: string): string | null {
+  public getItem(key: string): string | null {
     return localStorage.getItem(key);
   }
 
-  setItem(key: string, value: string): void {
+  public setItem(key: string, value: string): void {
     localStorage.setItem(key, value);
   }
 }
@@ -17,11 +19,11 @@ class BrowserStorage implements IStorage {
 class NodeStorage implements IStorage {
   private storage: Record<string, string> = {};
 
-  getItem(key: string): string | null {
+  public getItem(key: string): string | null {
     return this.storage[key] || null;
   }
 
-  setItem(key: string, value: string): void {
+  public setItem(key: string, value: string): void {
     this.storage[key] = value;
   }
 }
@@ -36,11 +38,24 @@ export class LocalStorage {
         : new BrowserStorage();
   }
 
-  getItem(key: string): string | null {
-    return this.storage.getItem(key);
+  public getAuthSignature(key: string): AuthSignature | null {
+    const asJson = this.storage.getItem(key);
+    if (!asJson) {
+      return null;
+    }
+    return LocalStorage.fromJson(asJson);
   }
 
-  setItem(key: string, value: string): void {
-    this.storage.setItem(key, value);
+  public setAuthSignature(key: string, authSignature: AuthSignature): void {
+    const asJson = LocalStorage.toJson(authSignature);
+    this.storage.setItem(key, asJson);
+  }
+
+  public static fromJson(json: string): AuthSignature {
+    return authSignatureSchema.parse(JSON.parse(json));
+  }
+
+  public static toJson(signature: AuthSignature): string {
+    return JSON.stringify(signature);
   }
 }

--- a/packages/taco-auth/src/storage.ts
+++ b/packages/taco-auth/src/storage.ts
@@ -43,19 +43,11 @@ export class LocalStorage {
     if (!asJson) {
       return null;
     }
-    return LocalStorage.fromJson(asJson);
+    return authSignatureSchema.parse(JSON.parse(asJson));
   }
 
   public setAuthSignature(key: string, authSignature: AuthSignature): void {
-    const asJson = LocalStorage.toJson(authSignature);
+    const asJson = JSON.stringify(authSignature);
     this.storage.setItem(key, asJson);
-  }
-
-  public static fromJson(json: string): AuthSignature {
-    return authSignatureSchema.parse(JSON.parse(json));
-  }
-
-  public static toJson(signature: AuthSignature): string {
-    return JSON.stringify(signature);
   }
 }

--- a/packages/taco-auth/test/auth-provider.test.ts
+++ b/packages/taco-auth/test/auth-provider.test.ts
@@ -1,7 +1,8 @@
 import {
   bobSecretKeyBytes,
   fakeProvider,
-  fakeSigner, TEST_SIWE_PARAMS,
+  fakeSigner,
+  TEST_SIWE_PARAMS,
 } from '@nucypher/test-utils';
 import { SiweMessage } from 'siwe';
 import { describe, expect, it } from 'vitest';
@@ -12,7 +13,7 @@ import {
   EIP712TypedData,
 } from '../src';
 
-describe('taco authorization', () => {
+describe('auth provider', () => {
   it('creates a new EIP-712 message', async () => {
     const provider = fakeProvider(bobSecretKeyBytes);
     const signer = fakeSigner(bobSecretKeyBytes);
@@ -36,7 +37,7 @@ describe('taco authorization', () => {
     expect(typedData.message.blockNumber).toEqual(
       await provider.getBlockNumber(),
     );
-    expect(typedData.message).toHaveProperty('blockHash');
+    expect(typedData.message['blockHash']).toBeDefined();
   });
 
   it('creates a new SIWE message', async () => {

--- a/packages/taco-auth/test/auth-sig.test.ts
+++ b/packages/taco-auth/test/auth-sig.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  authSignatureSchema,
+} from '../src';
+
+const eip712AuthSignature = {
+  'signature': 'fake-typed-signature',
+  'address': '0x0000000000000000000000000000000000000000',
+  'scheme': 'EIP712',
+  'typedData': {
+    'types': {
+      'Wallet': [
+        {
+          'name': 'address',
+          'type': 'address',
+        },
+        {
+          'name': 'signatureText',
+          'type': 'string',
+        },
+        {
+          'name': 'blockNumber',
+          'type': 'uint256',
+        },
+        {
+          'name': 'blockHash',
+          'type': 'bytes32',
+        },
+      ],
+      'EIP712Domain': [
+        {
+          'name': 'name',
+          'type': 'string',
+        },
+        {
+          'name': 'version',
+          'type': 'string',
+        },
+        {
+          'name': 'chainId',
+          'type': 'uint256',
+        },
+        {
+          'name': 'salt',
+          'type': 'bytes32',
+        },
+      ],
+    },
+    'domain': {
+      'name': 'TACo',
+      'version': '1',
+      'chainId': 1234,
+      'salt': '0x55d90a3b041db6dda74671bc83a25d1508979b19a105be17f57f86fe08627dbd',
+    },
+    'message': {
+      'address': '0x0000000000000000000000000000000000000000',
+      'signatureText': 'I\'m the owner of address 0x0000000000000000000000000000000000000000 as of block number 1000',
+      'blockNumber': 1000,
+      'blockHash': '0x0000000000000000000000000000000000000000',
+    },
+    'primaryType': 'Wallet',
+  },
+};
+const eip4361AuthSignature = {
+  'signature': 'fake-signature',
+  'address': '0x0000000000000000000000000000000000000000',
+  'scheme': 'EIP4361',
+  'typedData': 'localhost wants you to sign in with your Ethereum account:\n0x0000000000000000000000000000000000000000\n\nlocalhost wants you to sign in with your Ethereum account: 0x0000000000000000000000000000000000000000\n\nURI: http://localhost:3000\nVersion: 1\nChain ID: 1234\nNonce: 5ixAg1odyfDnrbfGa\nIssued At: 2024-07-01T10:32:39.631Z',
+};
+
+describe('auth signature', () => {
+  it('accepts a well-formed EIP172 auth signature', async () => {
+    authSignatureSchema.parse(eip712AuthSignature);
+  });
+
+  it('rejects an EIP712 auth signature with missing fields', async () => {
+    expect(() => authSignatureSchema.parse({
+      ...eip712AuthSignature,
+      'signature': undefined,
+    })).toThrow();
+  });
+
+  it('accepts a well-formed EIP4361 auth signature', async () => {
+    authSignatureSchema.parse(eip4361AuthSignature);
+  });
+
+  it('rejects an EIP4361 auth signature with missing fields', async () => {
+    expect(() => authSignatureSchema.parse({
+      ...eip4361AuthSignature,
+      'signature': undefined,
+    })).toThrow();
+  });
+});

--- a/packages/taco/package.json
+++ b/packages/taco/package.json
@@ -44,7 +44,7 @@
     "@nucypher/taco-auth": "workspace:*",
     "ethers": "*",
     "semver": "^7.5.2",
-    "zod": "^3.22.4"
+    "zod": "*"
   },
   "devDependencies": {
     "@nucypher/test-utils": "workspace:*",

--- a/packages/taco/src/conditions/base/contract.ts
+++ b/packages/taco/src/conditions/base/contract.ts
@@ -1,8 +1,8 @@
+import { ETH_ADDRESS_REGEXP } from '@nucypher/shared';
 import { ethers } from 'ethers';
 import { z } from 'zod';
 
 import { Condition } from '../condition';
-import { ETH_ADDRESS_REGEXP } from '../const';
 import { OmitConditionType, paramOrContextParamSchema } from '../shared';
 
 import { rpcConditionSchema } from './rpc';

--- a/packages/taco/src/conditions/const.ts
+++ b/packages/taco/src/conditions/const.ts
@@ -8,8 +8,6 @@ import {
 export const USER_ADDRESS_PARAM_EXTERNAL_EIP4361 =
   ':userAddressExternalEIP4361';
 
-export const ETH_ADDRESS_REGEXP = new RegExp('^0x[a-fA-F0-9]{40}$');
-
 // Only allow alphanumeric characters and underscores
 export const CONTEXT_PARAM_REGEXP = new RegExp('^:[a-zA-Z_][a-zA-Z0-9_]*$');
 
@@ -35,5 +33,4 @@ export const RESERVED_CONTEXT_PARAMS = [
   USER_ADDRESS_PARAM_EIP712,
   USER_ADDRESS_PARAM_EIP4361,
   // USER_ADDRESS_PARAM_EXTERNAL_EIP4361 is not reserved and can be used as a custom context parameter
-  // USER_ADDRESS_PARAM_EXTERNAL_EIP4361
 ];

--- a/packages/taco/src/conditions/shared.ts
+++ b/packages/taco/src/conditions/shared.ts
@@ -1,3 +1,4 @@
+import { EthAddressSchema } from '@nucypher/shared';
 import {
   USER_ADDRESS_PARAM_DEFAULT,
   USER_ADDRESS_PARAM_EIP4361,
@@ -8,9 +9,6 @@ import { z } from 'zod';
 import {
   CONTEXT_PARAM_PREFIX,
   CONTEXT_PARAM_REGEXP,
-  ETH_ADDRESS_REGEXP,
-
-
 } from './const';
 
 export const contextParamSchema = z.string().regex(CONTEXT_PARAM_REGEXP);
@@ -40,8 +38,6 @@ export const returnValueTestSchema = z.object({
 });
 
 export type ReturnValueTestProps = z.infer<typeof returnValueTestSchema>;
-
-const EthAddressSchema = z.string().regex(ETH_ADDRESS_REGEXP);
 
 const UserAddressSchema = z.enum([
   USER_ADDRESS_PARAM_EIP712,

--- a/packages/taco/test/conditions/base/rpc.test.ts
+++ b/packages/taco/test/conditions/base/rpc.test.ts
@@ -89,10 +89,10 @@ describe('validation', () => {
       expect(result.error?.format()).toMatchObject({
         parameters: {
           '1': {
-            _errors: ['Invalid'],
+            _errors: ['Invalid', 'Invalid Ethereum address'],
           },
           '2': {
-            _errors: ['Invalid'],
+            _errors: ['Invalid', 'Invalid Ethereum address'],
           },
         },
       });

--- a/packages/taco/test/conditions/context.test.ts
+++ b/packages/taco/test/conditions/context.test.ts
@@ -1,9 +1,11 @@
 import { initialize } from '@nucypher/nucypher-core';
 import {
   AuthProviders,
-  AuthSignature, EIP4361_AUTH_METHOD,
+  AuthSignature,
+  EIP4361_AUTH_METHOD,
   EIP4361AuthProvider,
-  EIP712AuthProvider, EIP712TypedData,
+  EIP712AuthProvider,
+  EIP712TypedData,
   makeAuthProviders,
 } from '@nucypher/taco-auth';
 import {

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -34,7 +34,7 @@
     "@nucypher/taco-auth": "workspace:*",
     "axios": "^1.6.8",
     "ethers": "^5.7.2",
-    "vitest": "^1.3.1"
+    "vitest": "*"
   },
   "engines": {
     "node": ">=18",

--- a/packages/test-utils/src/utils.ts
+++ b/packages/test-utils/src/utils.ts
@@ -53,7 +53,11 @@ export const fromBytes = (bytes: Uint8Array): string =>
 
 export const fakePorterUri = 'https://_this_should_crash.com/';
 
-const makeFakeProvider = (timestamp: number, blockNumber: number, blockHash: string) => {
+const makeFakeProvider = (
+  timestamp: number,
+  blockNumber: number,
+  blockHash: string
+) => {
   const block = { timestamp, hash: blockHash };
   return {
     getBlockNumber: () => Promise.resolve(blockNumber),

--- a/packages/test-utils/src/utils.ts
+++ b/packages/test-utils/src/utils.ts
@@ -53,8 +53,8 @@ export const fromBytes = (bytes: Uint8Array): string =>
 
 export const fakePorterUri = 'https://_this_should_crash.com/';
 
-const makeFakeProvider = (timestamp: number, blockNumber: number) => {
-  const block = { timestamp };
+const makeFakeProvider = (timestamp: number, blockNumber: number, blockHash: string) => {
+  const block = { timestamp, hash: blockHash };
   return {
     getBlockNumber: () => Promise.resolve(blockNumber),
     getBlock: () => Promise.resolve(block),
@@ -67,8 +67,9 @@ export const fakeSigner = (
   secretKeyBytes = SecretKey.random().toBEBytes(),
   blockNumber = 1000,
   blockTimestamp = 1000,
+  blockHash = '0x0000000000000000000000000000000000000000',
 ) => {
-  const provider = makeFakeProvider(blockNumber, blockTimestamp);
+  const provider = makeFakeProvider(blockNumber, blockTimestamp, blockHash);
   return {
     ...new Wallet(secretKeyBytes),
     provider: provider,
@@ -85,8 +86,9 @@ export const fakeProvider = (
   secretKeyBytes = SecretKey.random().toBEBytes(),
   blockNumber = 1000,
   blockTimestamp = 1000,
+  blockHash = '0x0000000000000000000000000000000000000000',
 ): ethers.providers.Web3Provider => {
-  const fakeProvider = makeFakeProvider(blockTimestamp, blockNumber);
+  const fakeProvider = makeFakeProvider(blockTimestamp, blockNumber, blockHash);
   const fakeSignerWithProvider = fakeSigner(
     secretKeyBytes,
     blockNumber,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -603,7 +603,7 @@ importers:
         specifier: ^5.7.2
         version: 5.7.2(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       vitest:
-        specifier: ^1.3.1
+        specifier: '*'
         version: 1.6.0(@types/node@20.14.2)(jsdom@16.7.0)(terser@5.31.0)
 
 packages:
@@ -19005,7 +19005,7 @@ snapshots:
   vite-node@1.6.0(@types/node@20.14.2)(terser@5.31.0):
     dependencies:
       cac: 6.7.14
-      debug: 4.3.4
+      debug: 4.3.5
       pathe: 1.1.2
       picocolors: 1.0.1
       vite: 5.2.11(@types/node@20.14.2)(terser@5.31.0)
@@ -19038,7 +19038,7 @@ snapshots:
       '@vitest/utils': 1.6.0
       acorn-walk: 8.3.2
       chai: 4.4.1
-      debug: 4.3.4
+      debug: 4.3.5
       execa: 8.0.1
       local-pkg: 0.5.0
       magic-string: 0.30.10

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -512,6 +512,9 @@ importers:
       qs:
         specifier: ^6.12.1
         version: 6.12.1
+      zod:
+        specifier: '*'
+        version: 3.23.8
     devDependencies:
       '@typechain/ethers-v5':
         specifier: ^11.1.2
@@ -553,7 +556,7 @@ importers:
         specifier: ^7.5.2
         version: 7.6.2
       zod:
-        specifier: ^3.22.4
+        specifier: '*'
         version: 3.23.8
     devDependencies:
       '@nucypher/test-utils':
@@ -574,6 +577,9 @@ importers:
       siwe:
         specifier: ^2.3.2
         version: 2.3.2(ethers@5.7.2)
+      zod:
+        specifier: ^3.22.4
+        version: 3.23.8
     devDependencies:
       '@nucypher/test-utils':
         specifier: workspace:*


### PR DESCRIPTION
**Type of PR:**
- Feature

**Required reviews:**
- 2

**What this does:**
- Implements `AuthSignature` validation with `zod`
- Moves some code around in `taco-auth` to prevent circular-dependency issues that break `zod`

**Issues fixed/closed:**
- Fixes https://github.com/nucypher/taco-web/issues/535

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
- ...