### PR TITLE
Reuse siwe authentication

### DIFF
--- a/examples/taco/nodejs/src/index.ts
+++ b/examples/taco/nodejs/src/index.ts
@@ -89,7 +89,11 @@ const decryptFromBytes = async (encryptedBytes: Uint8Array) => {
     domain: 'localhost',
     uri: 'http://localhost:3000',
   };
-  const authProvider = new EIP4361AuthProvider(provider, consumerSigner, siweParams);
+  const authProvider = new EIP4361AuthProvider(
+    provider,
+    consumerSigner,
+    siweParams,
+  );
   return decrypt(
     provider,
     domain,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,9 +1,9 @@
 export * from './contracts';
 export * from './porter';
+export * from './schemas';
 export type * from './types';
 export * from './utils';
 export * from './web3';
-export * from './schemas';
 
 // Re-exports
 export {

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -11,6 +11,7 @@ const isAddress = (address: string) => {
   }
 };
 
-export const EthAddressSchema = z.string()
+export const EthAddressSchema = z
+  .string()
   .regex(ETH_ADDRESS_REGEXP)
   .refine(isAddress, { message: 'Invalid Ethereum address' });

--- a/packages/shared/test/schemas.test.ts
+++ b/packages/shared/test/schemas.test.ts
@@ -1,7 +1,6 @@
-import {describe, expect, it} from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import { EthAddressSchema } from '../src';
-
 
 describe('ethereum address schema', () => {
   it('should accept valid ethereum address', () => {

--- a/packages/taco-auth/src/auth-sig.ts
+++ b/packages/taco-auth/src/auth-sig.ts
@@ -14,15 +14,3 @@ export const authSignatureSchema = z.object({
 });
 
 export type AuthSignature = z.infer<typeof authSignatureSchema>;
-
-// TODO: create a AuthSignature class.
-
-// TODO: Where do we get the signature from?
-export const fromSIWEMessage = (siweMessage: SiweMessage, signature: ???): AuthSignature => {
-  return {
-    signature: ???
-    address: siweMessage.address,
-    scheme: EIP4361_AUTH_METHOD,
-    typedData: siweMessage.prepareMessage()
-  }
-}

--- a/packages/taco-auth/src/auth-sig.ts
+++ b/packages/taco-auth/src/auth-sig.ts
@@ -3,8 +3,6 @@ import { z } from 'zod';
 
 import { EIP4361_AUTH_METHOD } from './auth-provider';
 import { EIP4361TypedDataSchema } from './providers';
-import { SiweMessage } from 'siwe';
-
 
 export const authSignatureSchema = z.object({
   signature: z.string(),

--- a/packages/taco-auth/src/auth-sig.ts
+++ b/packages/taco-auth/src/auth-sig.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 
 import { EIP4361_AUTH_METHOD } from './auth-provider';
 import { EIP4361TypedDataSchema } from './providers';
+import { SiweMessage } from 'siwe';
 
 
 export const authSignatureSchema = z.object({
@@ -13,3 +14,15 @@ export const authSignatureSchema = z.object({
 });
 
 export type AuthSignature = z.infer<typeof authSignatureSchema>;
+
+// TODO: create a AuthSignature class.
+
+// TODO: Where do we get the signature from?
+export const fromSIWEMessage = (siweMessage: SiweMessage, signature: ???): AuthSignature => {
+  return {
+    signature: ???
+    address: siweMessage.address,
+    scheme: EIP4361_AUTH_METHOD,
+    typedData: siweMessage.prepareMessage()
+  }
+}

--- a/packages/taco-auth/src/index.ts
+++ b/packages/taco-auth/src/index.ts
@@ -1,3 +1,3 @@
-export * from './providers';
-export * from './auth-sig';
 export * from './auth-provider';
+export * from './auth-sig';
+export * from './providers';

--- a/packages/taco-auth/src/providers/eip4361.ts
+++ b/packages/taco-auth/src/providers/eip4361.ts
@@ -86,7 +86,7 @@ export class EIP4361AuthProvider {
       nonce,
       chainId,
     });
-    const scheme = 'EIP4361';
+    const scheme = EIP4361_AUTH_METHOD;
     const message = siweMessage.prepareMessage();
     const signature = await this.signer.signMessage(message);
     return { signature, address, scheme, typedData: message };

--- a/packages/taco-auth/src/providers/eip4361.ts
+++ b/packages/taco-auth/src/providers/eip4361.ts
@@ -15,13 +15,14 @@ const isSiweMessage = (message: string): boolean => {
   }
 };
 
-export const EIP4361TypedDataSchema = z.string()
+export const EIP4361TypedDataSchema = z
+  .string()
   .refine(isSiweMessage, { message: 'Invalid SIWE message' });
 
 export type EIP4361AuthProviderParams = {
   domain: string;
   uri: string;
-}
+};
 
 const ERR_MISSING_SIWE_PARAMETERS = 'Missing default SIWE parameters';
 

--- a/packages/taco-auth/src/providers/external-eip4361.ts
+++ b/packages/taco-auth/src/providers/external-eip4361.ts
@@ -3,14 +3,20 @@ import { SiweMessage } from 'siwe';
 import { EIP4361_AUTH_METHOD } from '../auth-provider';
 import { AuthSignature } from '../auth-sig';
 
-
 export class SingleSignOnEIP4361AuthProvider {
-  public static async fromExistingSiweInfo(existingSiweMessage: string, signature: string): Promise<SingleSignOnEIP4361AuthProvider> {
+  public static async fromExistingSiweInfo(
+    existingSiweMessage: string,
+    signature: string,
+  ): Promise<SingleSignOnEIP4361AuthProvider> {
     // validation
     const siweMessage = new SiweMessage(existingSiweMessage);
-    await siweMessage.verify({signature});
+    await siweMessage.verify({ signature });
     // create provider
-    const authProvider = new SingleSignOnEIP4361AuthProvider(siweMessage.prepareMessage(), siweMessage.address, signature);
+    const authProvider = new SingleSignOnEIP4361AuthProvider(
+      siweMessage.prepareMessage(),
+      siweMessage.address,
+      signature,
+    );
     return authProvider;
   }
 
@@ -18,11 +24,15 @@ export class SingleSignOnEIP4361AuthProvider {
     private readonly existingSiweMessage: string,
     private readonly address: string,
     private readonly signature: string,
-  ) {
-  }
+  ) {}
 
   public async getOrCreateAuthSignature(): Promise<AuthSignature> {
     const scheme = EIP4361_AUTH_METHOD;
-    return { signature: this.signature, address: this.address, scheme, typedData: this.existingSiweMessage };
+    return {
+      signature: this.signature,
+      address: this.address,
+      scheme,
+      typedData: this.existingSiweMessage,
+    };
   }
 }

--- a/packages/taco-auth/src/providers/external-eip4361.ts
+++ b/packages/taco-auth/src/providers/external-eip4361.ts
@@ -1,0 +1,28 @@
+import { SiweMessage } from 'siwe';
+
+import { EIP4361_AUTH_METHOD } from '../auth-provider';
+import { AuthSignature } from '../auth-sig';
+
+
+export class SingleSignOnEIP4361AuthProvider {
+  public static async fromExistingSiweInfo(existingSiweMessage: string, signature: string): Promise<SingleSignOnEIP4361AuthProvider> {
+    // validation
+    const siweMessage = new SiweMessage(existingSiweMessage);
+    await siweMessage.verify({signature});
+    // create provider
+    const authProvider = new SingleSignOnEIP4361AuthProvider(siweMessage.prepareMessage(), siweMessage.address, signature);
+    return authProvider;
+  }
+
+  private constructor(
+    private readonly existingSiweMessage: string,
+    private readonly address: string,
+    private readonly signature: string,
+  ) {
+  }
+
+  public async getOrCreateAuthSignature(): Promise<AuthSignature> {
+    const scheme = EIP4361_AUTH_METHOD;
+    return { signature: this.signature, address: this.address, scheme, typedData: this.existingSiweMessage };
+  }
+}

--- a/packages/taco-auth/src/providers/index.ts
+++ b/packages/taco-auth/src/providers/index.ts
@@ -1,1 +1,2 @@
 export * from './eip4361';
+export * from './external-eip4361';

--- a/packages/taco-auth/test/auth-provider.test.ts
+++ b/packages/taco-auth/test/auth-provider.test.ts
@@ -12,7 +12,11 @@ import { EIP4361AuthProvider, EIP4361TypedDataSchema } from '../src';
 describe('auth provider', () => {
   const provider = fakeProvider(bobSecretKeyBytes);
   const signer = fakeSigner(bobSecretKeyBytes);
-  const eip4361Provider = new EIP4361AuthProvider(provider, signer, TEST_SIWE_PARAMS);
+  const eip4361Provider = new EIP4361AuthProvider(
+    provider,
+    signer,
+    TEST_SIWE_PARAMS,
+  );
 
   it('creates a new SIWE message', async () => {
     const typedSignature = await eip4361Provider.getOrCreateAuthSignature();
@@ -42,6 +46,8 @@ describe('auth provider', () => {
   it('rejects an invalid EIP4361 message', async () => {
     const typedSignature = await eip4361Provider.getOrCreateAuthSignature();
     typedSignature.typedData = 'invalid-typed-data';
-    expect(() => EIP4361TypedDataSchema.parse(typedSignature.typedData)).toThrow();
+    expect(() =>
+      EIP4361TypedDataSchema.parse(typedSignature.typedData),
+    ).toThrow();
   });
 });

--- a/packages/taco-auth/test/auth-sig.test.ts
+++ b/packages/taco-auth/test/auth-sig.test.ts
@@ -2,12 +2,12 @@ import { describe, expect, it } from 'vitest';
 
 import { authSignatureSchema } from '../src';
 
-
 const eip4361AuthSignature = {
-  'signature': 'fake-signature',
-  'address': '0x0000000000000000000000000000000000000000',
-  'scheme': 'EIP4361',
-  'typedData': 'localhost wants you to sign in with your Ethereum account:\n0x0000000000000000000000000000000000000000\n\nlocalhost wants you to sign in with your Ethereum account: 0x0000000000000000000000000000000000000000\n\nURI: http://localhost:3000\nVersion: 1\nChain ID: 1234\nNonce: 5ixAg1odyfDnrbfGa\nIssued At: 2024-07-01T10:32:39.631Z',
+  signature: 'fake-signature',
+  address: '0x0000000000000000000000000000000000000000',
+  scheme: 'EIP4361',
+  typedData:
+    'localhost wants you to sign in with your Ethereum account:\n0x0000000000000000000000000000000000000000\n\nlocalhost wants you to sign in with your Ethereum account: 0x0000000000000000000000000000000000000000\n\nURI: http://localhost:3000\nVersion: 1\nChain ID: 1234\nNonce: 5ixAg1odyfDnrbfGa\nIssued At: 2024-07-01T10:32:39.631Z',
 };
 
 describe('auth signature', () => {
@@ -16,9 +16,11 @@ describe('auth signature', () => {
   });
 
   it('rejects an EIP4361 auth signature with missing fields', async () => {
-    expect(() => authSignatureSchema.parse({
-      ...eip4361AuthSignature,
-      'signature': undefined,
-    })).toThrow();
+    expect(() =>
+      authSignatureSchema.parse({
+        ...eip4361AuthSignature,
+        signature: undefined,
+      }),
+    ).toThrow();
   });
 });

--- a/packages/taco/examples/conditions.ts
+++ b/packages/taco/examples/conditions.ts
@@ -7,7 +7,10 @@ const ownsNFT = new conditions.predefined.erc721.ERC721Ownership({
   parameters: [3591],
   chain: ChainId.SEPOLIA,
 });
-console.assert(ownsNFT.requiresAuthentication(), 'ERC721Ownership requires authentication');
+console.assert(
+  ownsNFT.requiresAuthentication(),
+  'ERC721Ownership requires authentication',
+);
 
 const hasAtLeastTwoNFTs = new conditions.predefined.erc721.ERC721Balance({
   contractAddress: '0x1e988ba4692e52Bc50b375bcC8585b95c48AaD77',

--- a/packages/taco/examples/encrypt-decrypt.ts
+++ b/packages/taco/examples/encrypt-decrypt.ts
@@ -4,7 +4,8 @@ import { ethers } from 'ethers';
 import {
   conditions,
   decrypt,
-  domains, EIP4361AuthProvider,
+  domains,
+  EIP4361AuthProvider,
   encrypt,
   getPorterUri,
   initialize,
@@ -45,7 +46,10 @@ const run = async () => {
 
     // @ts-ignore
     const web3Provider = new ethers.providers.Web3Provider(window.ethereum);
-    const authProvider = new EIP4361AuthProvider(web3Provider, web3Provider.getSigner());
+    const authProvider = new EIP4361AuthProvider(
+      web3Provider,
+      web3Provider.getSigner(),
+    );
     const decryptedMessage = await decrypt(
       web3Provider,
       domains.TESTNET,

--- a/packages/taco/src/conditions/condition-expr.ts
+++ b/packages/taco/src/conditions/condition-expr.ts
@@ -1,11 +1,11 @@
 import { Conditions as CoreConditions } from '@nucypher/nucypher-core';
 import { toJSON } from '@nucypher/shared';
-import {AuthProviders} from "@nucypher/taco-auth";
+import { AuthProviders } from '@nucypher/taco-auth';
 import { SemVer } from 'semver';
 
 import { Condition } from './condition';
 import { ConditionFactory } from './condition-factory';
-import { ConditionContext, CustomContextParam} from './context';
+import { ConditionContext, CustomContextParam } from './context';
 
 const ERR_VERSION = (provided: string, current: string) =>
   `Version provided, ${provided}, is incompatible with current version, ${current}`;

--- a/packages/taco/src/conditions/const.ts
+++ b/packages/taco/src/conditions/const.ts
@@ -1,5 +1,5 @@
 import { ChainId } from '@nucypher/shared';
-import { USER_ADDRESS_PARAM_DEFAULT } from "@nucypher/taco-auth";
+import { USER_ADDRESS_PARAM_DEFAULT } from '@nucypher/taco-auth';
 
 export const USER_ADDRESS_PARAM_EXTERNAL_EIP4361 =
   ':userAddressExternalEIP4361';

--- a/packages/taco/src/conditions/predefined/erc20.ts
+++ b/packages/taco/src/conditions/predefined/erc20.ts
@@ -1,11 +1,10 @@
-import {USER_ADDRESS_PARAM_DEFAULT} from "@nucypher/taco-auth";
+import { USER_ADDRESS_PARAM_DEFAULT } from '@nucypher/taco-auth';
 
 import {
   ContractCondition,
   ContractConditionProps,
   ContractConditionType,
 } from '../base/contract';
-
 
 type ERC20BalanceFields = 'contractAddress' | 'chain' | 'returnValueTest';
 

--- a/packages/taco/src/conditions/predefined/erc721.ts
+++ b/packages/taco/src/conditions/predefined/erc721.ts
@@ -1,11 +1,10 @@
-import {USER_ADDRESS_PARAM_DEFAULT} from "@nucypher/taco-auth";
+import { USER_ADDRESS_PARAM_DEFAULT } from '@nucypher/taco-auth';
 
 import {
   ContractCondition,
   ContractConditionProps,
   ContractConditionType,
 } from '../base/contract';
-
 
 type ERC721OwnershipFields = 'contractAddress' | 'chain' | 'parameters';
 

--- a/packages/taco/src/conditions/shared.ts
+++ b/packages/taco/src/conditions/shared.ts
@@ -1,5 +1,5 @@
 import { EthAddressSchema } from '@nucypher/shared';
-import { USER_ADDRESS_PARAM_DEFAULT } from "@nucypher/taco-auth";
+import { USER_ADDRESS_PARAM_DEFAULT } from '@nucypher/taco-auth';
 import { z } from 'zod';
 
 import {

--- a/packages/taco/src/conditions/shared.ts
+++ b/packages/taco/src/conditions/shared.ts
@@ -5,6 +5,8 @@ import { z } from 'zod';
 import {
   CONTEXT_PARAM_PREFIX,
   CONTEXT_PARAM_REGEXP,
+  // TODO consider moving this
+  USER_ADDRESS_PARAM_EXTERNAL_EIP4361,
 } from './const';
 
 export const contextParamSchema = z.string().regex(CONTEXT_PARAM_REGEXP);
@@ -37,6 +39,7 @@ export type ReturnValueTestProps = z.infer<typeof returnValueTestSchema>;
 
 const UserAddressSchema = z.enum([
   USER_ADDRESS_PARAM_DEFAULT,
+  USER_ADDRESS_PARAM_EXTERNAL_EIP4361,
 ]);
 export const EthAddressOrUserAddressSchema = z.union([
   EthAddressSchema,

--- a/packages/taco/src/taco.ts
+++ b/packages/taco/src/taco.ts
@@ -160,8 +160,8 @@ export const decrypt = async (
   const ritual = await DkgClient.getActiveRitual(provider, domain, ritualId);
   const authProviders: AuthProviders = authProvider
     ? {
-      [EIP4361_AUTH_METHOD]: authProvider,
-    }
+        [EIP4361_AUTH_METHOD]: authProvider,
+      }
     : {};
   return retrieveAndDecrypt(
     provider,

--- a/packages/taco/src/tdec.ts
+++ b/packages/taco/src/tdec.ts
@@ -19,12 +19,12 @@ import {
   PorterClient,
   toBytes,
 } from '@nucypher/shared';
-import {AuthProviders} from "@nucypher/taco-auth";
+import { AuthProviders } from '@nucypher/taco-auth';
 import { ethers } from 'ethers';
 import { arrayify, keccak256 } from 'ethers/lib/utils';
 
 import { ConditionExpression } from './conditions/condition-expr';
-import { ConditionContext, CustomContextParam} from './conditions/context';
+import { ConditionContext, CustomContextParam } from './conditions/context';
 
 const ERR_DECRYPTION_FAILED = (errors: unknown) =>
   `Threshold of responses not met; TACo decryption failed with errors: ${JSON.stringify(

--- a/packages/taco/src/types.ts
+++ b/packages/taco/src/types.ts
@@ -1,2 +1,5 @@
 // Re-exporting core types to avoid confusion with taco types
-export { Context as CoreContext, Conditions as CoreConditions } from '@nucypher/nucypher-core';
+export {
+  Conditions as CoreConditions,
+  Context as CoreContext,
+} from '@nucypher/nucypher-core';

--- a/packages/taco/test/conditions/base/contract.test.ts
+++ b/packages/taco/test/conditions/base/contract.test.ts
@@ -11,9 +11,7 @@ import {
   FunctionAbiProps,
 } from '../../../src/conditions/base/contract';
 import { ConditionExpression } from '../../../src/conditions/condition-expr';
-import {
-  USER_ADDRESS_PARAMS,
-} from '../../../src/conditions/const';
+import { USER_ADDRESS_PARAMS } from '../../../src/conditions/const';
 import { CustomContextParam } from '../../../src/conditions/context';
 import { testContractConditionObj, testFunctionAbi } from '../../test-utils';
 

--- a/packages/taco/test/conditions/condition-expr.test.ts
+++ b/packages/taco/test/conditions/condition-expr.test.ts
@@ -1,6 +1,6 @@
 import { initialize } from '@nucypher/nucypher-core';
 import { objectEquals, toJSON } from '@nucypher/shared';
-import {USER_ADDRESS_PARAM_DEFAULT} from "@nucypher/taco-auth";
+import { USER_ADDRESS_PARAM_DEFAULT } from '@nucypher/taco-auth';
 import { TEST_CHAIN_ID, TEST_CONTRACT_ADDR } from '@nucypher/test-utils';
 import { SemVer } from 'semver';
 import { beforeAll, describe, expect, it } from 'vitest';
@@ -204,7 +204,8 @@ describe('condition set', () => {
     it('serializes to and from WASM conditions', () => {
       const conditionExpr = new ConditionExpression(erc721Balance);
       const coreConditions = conditionExpr.toCoreCondition();
-      const fromCoreConditions = ConditionExpression.fromCoreConditions(coreConditions);
+      const fromCoreConditions =
+        ConditionExpression.fromCoreConditions(coreConditions);
       expect(conditionExpr.equals(fromCoreConditions)).toBeTruthy();
     });
 

--- a/packages/taco/test/conditions/context.test.ts
+++ b/packages/taco/test/conditions/context.test.ts
@@ -4,11 +4,13 @@ import {
   AuthSignature,
   EIP4361_AUTH_METHOD,
   EIP4361AuthProvider,
+  USER_ADDRESS_PARAM_DEFAULT,
 } from '@nucypher/taco-auth';
 import {
-  USER_ADDRESS_PARAM_DEFAULT,
-} from "@nucypher/taco-auth";
-import { fakeAuthProviders, fakeProvider, fakeSigner } from '@nucypher/test-utils';
+  fakeAuthProviders,
+  fakeProvider,
+  fakeSigner,
+} from '@nucypher/test-utils';
 import { ethers } from 'ethers';
 import { beforeAll, describe, expect, it, vi } from 'vitest';
 
@@ -93,7 +95,7 @@ describe('context', () => {
         expect(asObj[customParamKey]).toEqual(`0x${toHexString(customParam)}`);
       });
 
-      it('detects when a custom parameter is requested', ()=> {
+      it('detects when a custom parameter is requested', () => {
         const context = conditionExpr.buildContext({}, authProviders);
         expect(context.requestedParameters).toContain(customParamKey);
       });
@@ -101,7 +103,9 @@ describe('context', () => {
 
     describe('return value test', () => {
       it('accepts on a custom context parameters', async () => {
-        const asObj = await conditionExpr.buildContext(customParams).toContextParameters();
+        const asObj = await conditionExpr
+          .buildContext(customParams)
+          .toContextParameters();
         expect(asObj).toBeDefined();
         expect(asObj[customParamKey]).toEqual(1234);
       });
@@ -166,8 +170,8 @@ describe('context', () => {
       } as ContractConditionProps;
       const condition = new ContractCondition(conditionObj);
       const conditionExpr = new ConditionExpression(condition);
-      expect(conditionExpr.buildContext( {}, authProviders)).toBeDefined();
-      expect(() => conditionExpr.buildContext( {})).toThrow(
+      expect(conditionExpr.buildContext({}, authProviders)).toBeDefined();
+      expect(() => conditionExpr.buildContext({})).toThrow(
         `No matching authentication provider to satisfy ${USER_ADDRESS_PARAM_DEFAULT} context variable in condition`,
       );
     });
@@ -178,8 +182,8 @@ describe('context', () => {
       expect(
         JSON.stringify(condition.toObj()).includes(USER_ADDRESS_PARAM_DEFAULT),
       ).toBe(false);
-      expect(conditionExpr.buildContext( {}, authProviders)).toBeDefined();
-      expect(conditionExpr.buildContext( {})).toBeDefined();
+      expect(conditionExpr.buildContext({}, authProviders)).toBeDefined();
+      expect(conditionExpr.buildContext({})).toBeDefined();
     });
 
     it('rejects on a missing signer', () => {
@@ -192,7 +196,7 @@ describe('context', () => {
       };
       const condition = new ContractCondition(conditionObj);
       const conditionExpr = new ConditionExpression(condition);
-      expect(() => conditionExpr.buildContext( {}, undefined)).toThrow(
+      expect(() => conditionExpr.buildContext({}, undefined)).toThrow(
         `No matching authentication provider to satisfy ${USER_ADDRESS_PARAM_DEFAULT} context variable in condition`,
       );
     });
@@ -207,7 +211,7 @@ describe('context', () => {
       };
       const condition = new ContractCondition(conditionObj);
       const conditionExpr = new ConditionExpression(condition);
-      expect(() => conditionExpr.buildContext( {}, undefined)).toThrow(
+      expect(() => conditionExpr.buildContext({}, undefined)).toThrow(
         `No matching authentication provider to satisfy ${USER_ADDRESS_PARAM_DEFAULT} context variable in condition`,
       );
     });
@@ -224,10 +228,10 @@ describe('context', () => {
         },
       };
 
-      it('handles both custom and auth context parameters', ()=> {
-        const requestedParams = new ConditionExpression(contractCondition)
-          .buildContext( {}, authProviders)
-          .requestedParameters;
+      it('handles both custom and auth context parameters', () => {
+        const requestedParams = new ConditionExpression(
+          contractCondition,
+        ).buildContext({}, authProviders).requestedParameters;
         expect(requestedParams).not.toContain(USER_ADDRESS_PARAM_DEFAULT);
         expect(requestedParams).toContain(customParamKey);
       });
@@ -239,9 +243,11 @@ describe('context', () => {
         });
         const conditionContext = new ConditionExpression(
           customContractCondition,
-        ).buildContext( {}, authProviders);
+        ).buildContext({}, authProviders);
 
-        await expect(async () => conditionContext.toContextParameters()).rejects.toThrow(
+        await expect(async () =>
+          conditionContext.toContextParameters(),
+        ).rejects.toThrow(
           `Missing custom context parameter(s): ${customParamKey}`,
         );
       });
@@ -253,7 +259,7 @@ describe('context', () => {
         });
         const conditionContext = new ConditionExpression(
           customContractCondition,
-        ).buildContext( {}, authProviders);
+        ).buildContext({}, authProviders);
 
         const asObj = await conditionContext.toContextParameters();
         expect(asObj).toBeDefined();
@@ -271,7 +277,7 @@ describe('context', () => {
           customParameters[customParamKey] = falsyParam;
           const conditionContext = new ConditionExpression(
             customContractCondition,
-          ).buildContext( customParameters, authProviders);
+          ).buildContext(customParameters, authProviders);
 
           const asObj = await conditionContext.toContextParameters();
           expect(asObj).toBeDefined();
@@ -325,7 +331,7 @@ describe('No authentication provider', () => {
       };
       const condition = new ContractCondition(conditionObj);
       const conditionExpr = new ConditionExpression(condition);
-      expect(() => conditionExpr.buildContext( {}, {})).toThrow(
+      expect(() => conditionExpr.buildContext({}, {})).toThrow(
         `No matching authentication provider to satisfy ${userAddressParam} context variable in condition`,
       );
     });
@@ -341,9 +347,7 @@ describe('No authentication provider', () => {
     };
     const condition = new ContractCondition(conditionObj);
     const conditionExpr = new ConditionExpression(condition);
-    expect(() =>
-      conditionExpr.buildContext( {}, authProviders),
-    ).not.toThrow();
+    expect(() => conditionExpr.buildContext({}, authProviders)).not.toThrow();
   });
 
   async function makeAuthSignature(authMethod: string) {
@@ -357,7 +361,7 @@ describe('No authentication provider', () => {
     const condition = new ContractCondition(conditionObj);
     const conditionExpr = new ConditionExpression(condition);
 
-    const builtContext = conditionExpr.buildContext( {}, authProviders);
+    const builtContext = conditionExpr.buildContext({}, authProviders);
     const contextVars = await builtContext.toContextParameters();
     const authSignature = contextVars[authMethod] as AuthSignature;
     expect(authSignature).toBeDefined();
@@ -406,9 +410,7 @@ describe('No authentication provider', () => {
     // Make sure we remove the EIP4361 auth method from the auth providers first
     delete authProviders[EIP4361_AUTH_METHOD];
     // Should throw an error if we don't pass the custom parameter
-    expect(
-      () => conditionExpr.buildContext( {}, authProviders)
-    ).toThrow(
+    expect(() => conditionExpr.buildContext({}, authProviders)).toThrow(
       `No custom parameter for requested context parameter: ${USER_ADDRESS_PARAM_EXTERNAL_EIP4361}`,
     );
 

--- a/packages/taco/test/conditions/predefined/erc721.test.ts
+++ b/packages/taco/test/conditions/predefined/erc721.test.ts
@@ -1,4 +1,4 @@
-import {USER_ADDRESS_PARAM_DEFAULT} from "@nucypher/taco-auth";
+import { USER_ADDRESS_PARAM_DEFAULT } from '@nucypher/taco-auth';
 import { TEST_CHAIN_ID, TEST_CONTRACT_ADDR } from '@nucypher/test-utils';
 import { describe, expect, it } from 'vitest';
 

--- a/packages/taco/test/taco.test.ts
+++ b/packages/taco/test/taco.test.ts
@@ -3,8 +3,8 @@ import {
   initialize,
   SessionStaticSecret,
 } from '@nucypher/nucypher-core';
-import { USER_ADDRESS_PARAM_DEFAULT } from '@nucypher/taco-auth';
 import * as tacoAuth from '@nucypher/taco-auth';
+import { USER_ADDRESS_PARAM_DEFAULT } from '@nucypher/taco-auth';
 import {
   aliceSecretKeyBytes,
   fakeDkgFlow,
@@ -14,7 +14,8 @@ import {
   fakeTDecFlow,
   mockGetRitualIdFromPublicKey,
   mockTacoDecrypt,
-  TEST_CHAIN_ID, TEST_SIWE_PARAMS,
+  TEST_CHAIN_ID,
+  TEST_SIWE_PARAMS,
 } from '@nucypher/test-utils';
 import { beforeAll, describe, expect, it } from 'vitest';
 
@@ -36,7 +37,6 @@ const ownsNFT = new conditions.predefined.erc721.ERC721Ownership({
   parameters: [3591],
   chain: TEST_CHAIN_ID,
 });
-
 
 describe('taco', () => {
   beforeAll(async () => {
@@ -83,7 +83,11 @@ describe('taco', () => {
     );
     const getRitualSpy = mockGetActiveRitual(mockedDkgRitual);
 
-    const authProvider = new tacoAuth.EIP4361AuthProvider(provider, signer, TEST_SIWE_PARAMS);
+    const authProvider = new tacoAuth.EIP4361AuthProvider(
+      provider,
+      signer,
+      TEST_SIWE_PARAMS,
+    );
     const decryptedMessage = await taco.decrypt(
       provider,
       domains.DEVNET,
@@ -107,11 +111,12 @@ describe('taco', () => {
     const getFinalizedRitualSpy = mockGetActiveRitual(mockedDkgRitual);
 
     const customParamKey = ':nftId';
-    const ownsNFTWithCustomParams = new conditions.predefined.erc721.ERC721Ownership({
-      contractAddress: '0x1e988ba4692e52Bc50b375bcC8585b95c48AaD77',
-      parameters: [customParamKey],
-      chain: TEST_CHAIN_ID,
-    });
+    const ownsNFTWithCustomParams =
+      new conditions.predefined.erc721.ERC721Ownership({
+        contractAddress: '0x1e988ba4692e52Bc50b375bcC8585b95c48AaD77',
+        parameters: [customParamKey],
+        chain: TEST_CHAIN_ID,
+      });
 
     const messageKit = await taco.encrypt(
       provider,
@@ -123,7 +128,12 @@ describe('taco', () => {
     );
     expect(getFinalizedRitualSpy).toHaveBeenCalled();
 
-    const requestedParameters = taco.conditions.context.ConditionContext.requestedContextParameters(messageKit);
-    expect(requestedParameters).toEqual(new Set([customParamKey, USER_ADDRESS_PARAM_DEFAULT]));
+    const requestedParameters =
+      taco.conditions.context.ConditionContext.requestedContextParameters(
+        messageKit,
+      );
+    expect(requestedParameters).toEqual(
+      new Set([customParamKey, USER_ADDRESS_PARAM_DEFAULT]),
+    );
   });
 });

--- a/packages/taco/test/test-utils.ts
+++ b/packages/taco/test/test-utils.ts
@@ -54,7 +54,6 @@ import { ReturnValueTestProps } from '../src/conditions/shared';
 import { DkgClient, DkgRitual } from '../src/dkg';
 import { encryptMessage } from '../src/tdec';
 
-
 export const fakeDkgTDecFlowE2E: (
   ritualId?: number,
   variant?: FerveoVariant,

--- a/packages/test-utils/src/utils.ts
+++ b/packages/test-utils/src/utils.ts
@@ -88,7 +88,11 @@ export const fakeSigner = (
 
 export const fakeAuthProviders = () => {
   return {
-    [EIP4361_AUTH_METHOD]: new EIP4361AuthProvider(fakeProvider(), fakeSigner(), TEST_SIWE_PARAMS),
+    [EIP4361_AUTH_METHOD]: new EIP4361AuthProvider(
+      fakeProvider(),
+      fakeSigner(),
+      TEST_SIWE_PARAMS,
+    ),
   };
 };
 
@@ -258,14 +262,14 @@ interface FakeDkgRitualFlow {
 }
 
 export const fakeTDecFlow = ({
-   validators,
-   validatorKeypairs,
-   ritualId,
-   sharesNum,
-   threshold,
-   receivedMessages,
-   message,
-   thresholdMessageKit,
+  validators,
+  validatorKeypairs,
+  ritualId,
+  sharesNum,
+  threshold,
+  receivedMessages,
+  message,
+  thresholdMessageKit,
 }: FakeDkgRitualFlow) => {
   // Having aggregated the transcripts, the validators can now create decryption shares
   const decryptionShares: DecryptionShareSimple[] = [];


### PR DESCRIPTION
**Type of PR:**

- [ ] Bugfix
- [X] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:**

- [ ] 1
- [ ] 2
- [x] 3

**What this does:**
Add support to reuse SIWE messages on taco-web from other applications.

**Issues fixed/closed:**
> - Fixes #...

Related to https://github.com/nucypher/sprints/issues/22

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
Based on #546 .
