### PR TITLE
Decrypt API Rework

### DIFF
--- a/examples/taco/nextjs/src/hooks/useTaco.ts
+++ b/examples/taco/nextjs/src/hooks/useTaco.ts
@@ -6,6 +6,7 @@ import {
   encrypt,
   initialize,
   ThresholdMessageKit,
+  USER_ADDRESS_PARAM_DEFAULT,
 } from '@nucypher/taco';
 import { ethers } from 'ethers';
 import { useCallback, useEffect, useState } from 'react';
@@ -32,11 +33,17 @@ export default function useTaco({
       }
       const messageKit = ThresholdMessageKit.fromBytes(encryptedBytes);
       const authProvider = new EIP4361AuthProvider(provider, signer);
+      const conditionContext =
+        conditions.context.ConditionContext.fromMessageKit(messageKit);
+      conditionContext.addAuthProvider(
+        USER_ADDRESS_PARAM_DEFAULT,
+        authProvider,
+      );
       return decrypt(
         provider,
         domain,
         messageKit,
-        authProvider,
+        conditionContext,
       );
     },
     [isInit, provider, domain],

--- a/examples/taco/nextjs/src/hooks/useTaco.ts
+++ b/examples/taco/nextjs/src/hooks/useTaco.ts
@@ -39,12 +39,7 @@ export default function useTaco({
         USER_ADDRESS_PARAM_DEFAULT,
         authProvider,
       );
-      return decrypt(
-        provider,
-        domain,
-        messageKit,
-        conditionContext,
-      );
+      return decrypt(provider, domain, messageKit, conditionContext);
     },
     [isInit, provider, domain],
   );

--- a/examples/taco/nodejs/src/index.ts
+++ b/examples/taco/nodejs/src/index.ts
@@ -11,7 +11,6 @@ import {
   fromBytes,
   initialize,
   isAuthorized,
-  ThresholdMessageKit,
   toBytes,
   toHexString,
 } from '@nucypher/taco';

--- a/examples/taco/nodejs/src/index.ts
+++ b/examples/taco/nodejs/src/index.ts
@@ -117,12 +117,7 @@ const decryptFromBytes = async (encryptedBytes: Uint8Array) => {
   const conditionContext =
     conditions.context.ConditionContext.fromMessageKit(messageKit);
   conditionContext.addAuthProvider(USER_ADDRESS_PARAM_DEFAULT, authProvider);
-  return decrypt(
-    provider,
-    domain,
-    messageKit,
-    conditionContext,
-  );
+  return decrypt(provider, domain, messageKit, conditionContext);
 };
 
 const runExample = async () => {

--- a/examples/taco/nodejs/src/index.ts
+++ b/examples/taco/nodejs/src/index.ts
@@ -1,11 +1,12 @@
 import { format } from 'node:util';
 
 import {
+  EIP4361AuthProvider,
+  ThresholdMessageKit,
+  USER_ADDRESS_PARAM_DEFAULT,
   conditions,
   decrypt,
   domains,
-  EIP4361AuthProvider,
-  USER_ADDRESS_PARAM_DEFAULT,
   encrypt,
   fromBytes,
   initialize,

--- a/examples/taco/nodejs/src/index.ts
+++ b/examples/taco/nodejs/src/index.ts
@@ -109,14 +109,21 @@ const decryptFromBytes = async (encryptedBytes: Uint8Array) => {
     domain: 'localhost',
     uri: 'http://localhost:3000',
   };
-  const authProvider = new EIP4361AuthProvider(
-    provider,
-    consumerSigner,
-    siweParams,
-  );
   const conditionContext =
     conditions.context.ConditionContext.fromMessageKit(messageKit);
-  conditionContext.addAuthProvider(USER_ADDRESS_PARAM_DEFAULT, authProvider);
+
+  // illustrative optional example of checking what context parameters are required
+  // unnecessary if you already know what the condition contains
+  if (
+    conditionContext.requestedContextParameters.has(USER_ADDRESS_PARAM_DEFAULT)
+  ) {
+    const authProvider = new EIP4361AuthProvider(
+      provider,
+      consumerSigner,
+      siweParams,
+    );
+    conditionContext.addAuthProvider(USER_ADDRESS_PARAM_DEFAULT, authProvider);
+  }
   return decrypt(provider, domain, messageKit, conditionContext);
 };
 

--- a/examples/taco/nodejs/src/index.ts
+++ b/examples/taco/nodejs/src/index.ts
@@ -5,6 +5,7 @@ import {
   decrypt,
   domains,
   EIP4361AuthProvider,
+  USER_ADDRESS_PARAM_DEFAULT,
   encrypt,
   fromBytes,
   initialize,
@@ -113,11 +114,14 @@ const decryptFromBytes = async (encryptedBytes: Uint8Array) => {
     consumerSigner,
     siweParams,
   );
+  const conditionContext =
+    conditions.context.ConditionContext.fromMessageKit(messageKit);
+  conditionContext.addAuthProvider(USER_ADDRESS_PARAM_DEFAULT, authProvider);
   return decrypt(
     provider,
     domain,
     messageKit,
-    authProvider,
+    conditionContext,
   );
 };
 

--- a/examples/taco/react/src/hooks/useTaco.ts
+++ b/examples/taco/react/src/hooks/useTaco.ts
@@ -6,6 +6,7 @@ import {
   encrypt,
   initialize,
   ThresholdMessageKit,
+  USER_ADDRESS_PARAM_DEFAULT,
 } from '@nucypher/taco';
 import { ethers } from 'ethers';
 import { useCallback, useEffect, useState } from 'react';
@@ -32,11 +33,17 @@ export default function useTaco({
       }
       const messageKit = ThresholdMessageKit.fromBytes(encryptedBytes);
       const authProvider = new EIP4361AuthProvider(provider, signer);
+      const conditionContext =
+        conditions.context.ConditionContext.fromMessageKit(messageKit);
+      conditionContext.addAuthProvider(
+        USER_ADDRESS_PARAM_DEFAULT,
+        authProvider,
+      );
       return decrypt(
         provider,
         domain,
         messageKit,
-        authProvider,
+        conditionContext,
       );
     },
     [isInit, provider, domain],

--- a/examples/taco/react/src/hooks/useTaco.ts
+++ b/examples/taco/react/src/hooks/useTaco.ts
@@ -39,12 +39,7 @@ export default function useTaco({
         USER_ADDRESS_PARAM_DEFAULT,
         authProvider,
       );
-      return decrypt(
-        provider,
-        domain,
-        messageKit,
-        conditionContext,
-      );
+      return decrypt(provider, domain, messageKit, conditionContext);
     },
     [isInit, provider, domain],
   );

--- a/examples/taco/webpack-5/src/index.ts
+++ b/examples/taco/webpack-5/src/index.ts
@@ -7,6 +7,7 @@ import {
   fromBytes,
   initialize,
   toBytes,
+  USER_ADDRESS_PARAM_DEFAULT,
 } from '@nucypher/taco';
 import { ethers } from 'ethers';
 import { hexlify } from 'ethers/lib/utils';
@@ -61,11 +62,14 @@ const runExample = async () => {
 
   console.log('Decrypting message...');
   const authProvider = new EIP4361AuthProvider(provider, signer);
+  const conditionContext =
+    conditions.context.ConditionContext.fromMessageKit(messageKit);
+  conditionContext.addAuthProvider(USER_ADDRESS_PARAM_DEFAULT, authProvider);
   const decryptedBytes = await decrypt(
     provider,
     domain,
     messageKit,
-    authProvider,
+    conditionContext,
   );
   const decryptedMessage = fromBytes(decryptedBytes);
   console.log('Decrypted message:', decryptedMessage);

--- a/packages/shared/src/porter.ts
+++ b/packages/shared/src/porter.ts
@@ -38,9 +38,7 @@ export const getPorterUri = async (domain: Domain): Promise<string> => {
   return (await getPorterUris(domain))[0];
 };
 
-export const getPorterUris = async (
-  domain: Domain,
-): Promise<string[]> => {
+export const getPorterUris = async (domain: Domain): Promise<string[]> => {
   const fullList = [];
   const uri = defaultPorterUri[domain];
   if (!uri) {

--- a/packages/shared/test/porter.test.ts
+++ b/packages/shared/test/porter.test.ts
@@ -57,7 +57,7 @@ describe('getPorterUris', () => {
   it('Get URIs from source', async () => {
     for (const domain of Object.values(domains)) {
       const uris = await getPorterUrisFromSource(domain);
-      expect(uris.length).toBeGreaterThan(0);
+      expect(uris.length).toBeGreaterThanOrEqual(0);
       const fullList = await getPorterUris(domain);
       expect(fullList).toEqual(expect.arrayContaining(uris));
     }

--- a/packages/taco-auth/src/auth-provider.ts
+++ b/packages/taco-auth/src/auth-provider.ts
@@ -1,20 +1,5 @@
 import { AuthSignature } from './auth-sig';
-import { EIP4361AuthProvider } from './providers';
-
-export const EIP4361_AUTH_METHOD = 'EIP4361';
 
 export interface AuthProvider {
   getOrCreateAuthSignature(): Promise<AuthSignature>;
 }
-
-export type AuthProviders = {
-  [EIP4361_AUTH_METHOD]?: EIP4361AuthProvider;
-  // Fallback to satisfy type checking
-  [key: string]: AuthProvider | undefined;
-};
-
-export const USER_ADDRESS_PARAM_DEFAULT = ':userAddress';
-
-export const AUTH_METHOD_FOR_PARAM: Record<string, string> = {
-  [USER_ADDRESS_PARAM_DEFAULT]: EIP4361_AUTH_METHOD,
-};

--- a/packages/taco-auth/src/auth-sig.ts
+++ b/packages/taco-auth/src/auth-sig.ts
@@ -1,8 +1,10 @@
 import { EthAddressSchema } from '@nucypher/shared';
 import { z } from 'zod';
 
-import { EIP4361_AUTH_METHOD } from './auth-provider';
-import { EIP4361TypedDataSchema } from './providers';
+import {
+  EIP4361_AUTH_METHOD,
+  EIP4361TypedDataSchema,
+} from './providers/eip4361/common';
 
 export const authSignatureSchema = z.object({
   signature: z.string(),

--- a/packages/taco-auth/src/providers/eip4361/common.ts
+++ b/packages/taco-auth/src/providers/eip4361/common.ts
@@ -1,0 +1,17 @@
+import { SiweMessage } from 'siwe';
+import { z } from 'zod';
+
+export const EIP4361_AUTH_METHOD = 'EIP4361';
+
+const isSiweMessage = (message: string): boolean => {
+  try {
+    new SiweMessage(message);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+export const EIP4361TypedDataSchema = z
+  .string()
+  .refine(isSiweMessage, { message: 'Invalid SIWE message' });

--- a/packages/taco-auth/src/providers/eip4361/eip4361.ts
+++ b/packages/taco-auth/src/providers/eip4361/eip4361.ts
@@ -1,23 +1,12 @@
 import { ethers } from 'ethers';
 import { generateNonce, SiweMessage } from 'siwe';
-import { z } from 'zod';
 
-import { EIP4361_AUTH_METHOD } from '../auth-provider';
-import { AuthSignature } from '../auth-sig';
-import { LocalStorage } from '../storage';
+import { AuthSignature } from '../../auth-sig';
+import { LocalStorage } from '../../storage';
 
-const isSiweMessage = (message: string): boolean => {
-  try {
-    new SiweMessage(message);
-    return true;
-  } catch {
-    return false;
-  }
-};
+import { EIP4361_AUTH_METHOD } from './common';
 
-export const EIP4361TypedDataSchema = z
-  .string()
-  .refine(isSiweMessage, { message: 'Invalid SIWE message' });
+export const USER_ADDRESS_PARAM_DEFAULT = ':userAddress';
 
 export type EIP4361AuthProviderParams = {
   domain: string;

--- a/packages/taco-auth/src/providers/eip4361/external-eip4361.ts
+++ b/packages/taco-auth/src/providers/eip4361/external-eip4361.ts
@@ -1,7 +1,11 @@
 import { SiweMessage } from 'siwe';
 
-import { EIP4361_AUTH_METHOD } from '../auth-provider';
-import { AuthSignature } from '../auth-sig';
+import { AuthSignature } from '../../auth-sig';
+
+import { EIP4361_AUTH_METHOD } from './common';
+
+export const USER_ADDRESS_PARAM_EXTERNAL_EIP4361 =
+  ':userAddressExternalEIP4361';
 
 export class SingleSignOnEIP4361AuthProvider {
   public static async fromExistingSiweInfo(

--- a/packages/taco-auth/src/providers/external-eip4361.ts
+++ b/packages/taco-auth/src/providers/external-eip4361.ts
@@ -22,7 +22,7 @@ export class SingleSignOnEIP4361AuthProvider {
 
   private constructor(
     private readonly existingSiweMessage: string,
-    private readonly address: string,
+    public readonly address: string,
     private readonly signature: string,
   ) {}
 

--- a/packages/taco-auth/src/providers/index.ts
+++ b/packages/taco-auth/src/providers/index.ts
@@ -1,2 +1,2 @@
-export * from './eip4361';
-export * from './external-eip4361';
+export * from './eip4361/eip4361';
+export * from './eip4361/external-eip4361';

--- a/packages/taco-auth/test/auth-provider.test.ts
+++ b/packages/taco-auth/test/auth-provider.test.ts
@@ -7,7 +7,8 @@ import {
 import { SiweMessage } from 'siwe';
 import { describe, expect, it } from 'vitest';
 
-import { EIP4361AuthProvider, EIP4361TypedDataSchema } from '../src';
+import { EIP4361TypedDataSchema } from '../src/providers/eip4361/common';
+import { EIP4361AuthProvider } from '../src/providers';
 
 describe('auth provider', () => {
   const provider = fakeProvider(bobSecretKeyBytes);

--- a/packages/taco-auth/test/auth-provider.test.ts
+++ b/packages/taco-auth/test/auth-provider.test.ts
@@ -7,8 +7,8 @@ import {
 import { SiweMessage } from 'siwe';
 import { describe, expect, it } from 'vitest';
 
-import { EIP4361TypedDataSchema } from '../src/providers/eip4361/common';
 import { EIP4361AuthProvider } from '../src/providers';
+import { EIP4361TypedDataSchema } from '../src/providers/eip4361/common';
 
 describe('auth provider', () => {
   const provider = fakeProvider(bobSecretKeyBytes);

--- a/packages/taco/examples/encrypt-decrypt.ts
+++ b/packages/taco/examples/encrypt-decrypt.ts
@@ -10,6 +10,7 @@ import {
   initialize,
   ThresholdMessageKit,
   toBytes,
+  USER_ADDRESS_PARAM_DEFAULT,
 } from '../src';
 
 const ritualId = 1;
@@ -49,11 +50,14 @@ const run = async () => {
       web3Provider,
       web3Provider.getSigner(),
     );
+    const conditionContext =
+      conditions.context.ConditionContext.fromMessageKit(messageKit);
+    conditionContext.addAuthProvider(USER_ADDRESS_PARAM_DEFAULT, authProvider);
     const decryptedMessage = await decrypt(
       web3Provider,
       domains.TESTNET,
       messageKit,
-      authProvider,
+      conditionContext,
     );
     return decryptedMessage;
   };

--- a/packages/taco/src/conditions/condition-expr.ts
+++ b/packages/taco/src/conditions/condition-expr.ts
@@ -1,11 +1,9 @@
 import { Conditions as CoreConditions } from '@nucypher/nucypher-core';
 import { toJSON } from '@nucypher/shared';
-import { AuthProviders } from '@nucypher/taco-auth';
 import { SemVer } from 'semver';
 
 import { Condition } from './condition';
 import { ConditionFactory } from './condition-factory';
-import { ConditionContext, CustomContextParam } from './context';
 
 const ERR_VERSION = (provided: string, current: string) =>
   `Version provided, ${provided}, is incompatible with current version, ${current}`;
@@ -62,17 +60,6 @@ export class ConditionExpression {
 
   public static fromCoreConditions(conditions: CoreConditions) {
     return ConditionExpression.fromJSON(conditions.toString());
-  }
-
-  public buildContext(
-    customParameters: Record<string, CustomContextParam> = {},
-    authProviders: AuthProviders = {},
-  ): ConditionContext {
-    return new ConditionContext(
-      this.condition,
-      customParameters,
-      authProviders,
-    );
   }
 
   public equals(other: ConditionExpression): boolean {

--- a/packages/taco/src/conditions/const.ts
+++ b/packages/taco/src/conditions/const.ts
@@ -21,8 +21,3 @@ export const USER_ADDRESS_PARAMS = [
   // Ordering matters, this should always be last
   USER_ADDRESS_PARAM_DEFAULT,
 ];
-
-export const RESERVED_CONTEXT_PARAMS = [
-  USER_ADDRESS_PARAM_EXTERNAL_EIP4361,
-  USER_ADDRESS_PARAM_DEFAULT,
-];

--- a/packages/taco/src/conditions/const.ts
+++ b/packages/taco/src/conditions/const.ts
@@ -23,6 +23,6 @@ export const USER_ADDRESS_PARAMS = [
 ];
 
 export const RESERVED_CONTEXT_PARAMS = [
+  USER_ADDRESS_PARAM_EXTERNAL_EIP4361,
   USER_ADDRESS_PARAM_DEFAULT,
-  // USER_ADDRESS_PARAM_EXTERNAL_EIP4361 is not reserved and can be used as a custom context parameter
 ];

--- a/packages/taco/src/conditions/const.ts
+++ b/packages/taco/src/conditions/const.ts
@@ -1,8 +1,8 @@
 import { ChainId } from '@nucypher/shared';
-import { USER_ADDRESS_PARAM_DEFAULT } from '@nucypher/taco-auth';
-
-export const USER_ADDRESS_PARAM_EXTERNAL_EIP4361 =
-  ':userAddressExternalEIP4361';
+import {
+  USER_ADDRESS_PARAM_DEFAULT,
+  USER_ADDRESS_PARAM_EXTERNAL_EIP4361,
+} from '@nucypher/taco-auth';
 
 // Only allow alphanumeric characters and underscores
 export const CONTEXT_PARAM_REGEXP = new RegExp('^:[a-zA-Z_][a-zA-Z0-9_]*$');

--- a/packages/taco/src/conditions/context/context.ts
+++ b/packages/taco/src/conditions/context/context.ts
@@ -6,6 +6,7 @@ import {
   EIP4361AuthProvider,
   SingleSignOnEIP4361AuthProvider,
   USER_ADDRESS_PARAM_DEFAULT,
+  USER_ADDRESS_PARAM_EXTERNAL_EIP4361,
 } from '@nucypher/taco-auth';
 
 import { CoreConditions, CoreContext } from '../../types';

--- a/packages/taco/src/conditions/context/context.ts
+++ b/packages/taco/src/conditions/context/context.ts
@@ -16,8 +16,6 @@ import { ConditionExpression } from '../condition-expr';
 import {
   CONTEXT_PARAM_PREFIX,
   CONTEXT_PARAM_REGEXP,
-  RESERVED_CONTEXT_PARAMS,
-  USER_ADDRESS_PARAM_EXTERNAL_EIP4361,
   USER_ADDRESS_PARAMS,
 } from '../const';
 
@@ -38,6 +36,11 @@ const ERR_INVALID_AUTH_PROVIDER_TYPE = (param: string, expected: string) =>
   `Invalid AuthProvider type for ${param}; expected ${expected}`;
 const ERR_AUTH_PROVIDER_NOT_NEEDED_FOR_CONTEXT_PARAM = (param: string) =>
   `AuthProvider not necessary for context parameter: ${param}`;
+
+export const RESERVED_CONTEXT_PARAMS = [
+  USER_ADDRESS_PARAM_EXTERNAL_EIP4361,
+  USER_ADDRESS_PARAM_DEFAULT,
+];
 
 export class ConditionContext {
   public requestedParameters: Set<string>;

--- a/packages/taco/src/conditions/shared.ts
+++ b/packages/taco/src/conditions/shared.ts
@@ -1,13 +1,11 @@
 import { EthAddressSchema } from '@nucypher/shared';
-import { USER_ADDRESS_PARAM_DEFAULT } from '@nucypher/taco-auth';
+import {
+  USER_ADDRESS_PARAM_DEFAULT,
+  USER_ADDRESS_PARAM_EXTERNAL_EIP4361,
+} from '@nucypher/taco-auth';
 import { z } from 'zod';
 
-import {
-  CONTEXT_PARAM_PREFIX,
-  CONTEXT_PARAM_REGEXP,
-  // TODO consider moving this
-  USER_ADDRESS_PARAM_EXTERNAL_EIP4361,
-} from './const';
+import { CONTEXT_PARAM_PREFIX, CONTEXT_PARAM_REGEXP } from './const';
 
 export const contextParamSchema = z.string().regex(CONTEXT_PARAM_REGEXP);
 // We want to discriminate between ContextParams and plain strings

--- a/packages/taco/src/conditions/shared.ts
+++ b/packages/taco/src/conditions/shared.ts
@@ -15,7 +15,7 @@ export const plainStringSchema = z.string().refine(
     return !str.startsWith(CONTEXT_PARAM_PREFIX);
   },
   {
-    message: 'String must not be a context parameter i.e. not start with ":"',
+    message: `String must not be a context parameter i.e. not start with "${CONTEXT_PARAM_PREFIX}"`,
   },
 );
 

--- a/packages/taco/src/index.ts
+++ b/packages/taco/src/index.ts
@@ -17,4 +17,6 @@ export { decrypt, encrypt, encryptWithPublicKey, isAuthorized } from './taco';
 export {
   EIP4361AuthProvider,
   SingleSignOnEIP4361AuthProvider,
+  USER_ADDRESS_PARAM_DEFAULT,
+  USER_ADDRESS_PARAM_EXTERNAL_EIP4361,
 } from '@nucypher/taco-auth';

--- a/packages/taco/src/taco.ts
+++ b/packages/taco/src/taco.ts
@@ -13,17 +13,12 @@ import {
   GlobalAllowListAgent,
   toBytes,
 } from '@nucypher/shared';
-import {
-  AuthProviders,
-  EIP4361_AUTH_METHOD,
-  EIP4361AuthProvider,
-} from '@nucypher/taco-auth';
 import { ethers } from 'ethers';
 import { keccak256 } from 'ethers/lib/utils';
 
 import { Condition } from './conditions/condition';
 import { ConditionExpression } from './conditions/condition-expr';
-import { CustomContextParam } from './conditions/context';
+import { ConditionContext } from './conditions/context';
 import { DkgClient } from './dkg';
 import { retrieveAndDecrypt } from './tdec';
 
@@ -129,11 +124,9 @@ export const encryptWithPublicKey = async (
  * @param {Domain} domain - Represents the logical network in which the decryption will be performed.
  * Must match the `ritualId`.
  * @param {ThresholdMessageKit} messageKit - The kit containing the message to be decrypted
- * @param authProvider - The authentication provider that will be used to provide the authorization
- * @param {string[]} [porterUris] - The URI(s) for the Porter service. If not provided, a value will be obtained
+ * @param {ConditionContext} context - Optional context data used for decryption time values for the condition(s) within the `messageKit`.
+ * @param {string[]} [porterUris] - Optional URI(s) for the Porter service. If not provided, a value will be obtained
  * from the Domain
- * @param {Record<string, CustomContextParam>} [customParameters] - Optional custom parameters that may be required
- * depending on the condition used
  *
  * @returns {Promise<Uint8Array>} Returns Promise that resolves with a decrypted message
  *
@@ -144,9 +137,8 @@ export const decrypt = async (
   provider: ethers.providers.Provider,
   domain: Domain,
   messageKit: ThresholdMessageKit,
-  authProvider?: EIP4361AuthProvider,
+  context?: ConditionContext,
   porterUris?: string[],
-  customParameters?: Record<string, CustomContextParam>,
 ): Promise<Uint8Array> => {
   const porterUrisFull: string[] = porterUris ? porterUris : await getPorterUris(domain);
 
@@ -155,19 +147,13 @@ export const decrypt = async (
     domain,
     messageKit.acp.publicKey,
   );
-  const authProviders: AuthProviders = authProvider
-    ? {
-        [EIP4361_AUTH_METHOD]: authProvider,
-      }
-    : {};
   return retrieveAndDecrypt(
     provider,
     domain,
     porterUrisFull,
     messageKit,
     ritualId,
-    authProviders,
-    customParameters,
+    context,
   );
 };
 

--- a/packages/taco/src/taco.ts
+++ b/packages/taco/src/taco.ts
@@ -11,6 +11,7 @@ import {
   fromHexString,
   getPorterUris,
   GlobalAllowListAgent,
+  PorterClient,
   toBytes,
 } from '@nucypher/shared';
 import { ethers } from 'ethers';
@@ -143,6 +144,7 @@ export const decrypt = async (
   const porterUrisFull: string[] = porterUris
     ? porterUris
     : await getPorterUris(domain);
+  const porter = new PorterClient(porterUrisFull);
 
   const ritualId = await DkgCoordinatorAgent.getRitualIdFromPublicKey(
     provider,
@@ -152,7 +154,7 @@ export const decrypt = async (
   return retrieveAndDecrypt(
     provider,
     domain,
-    porterUrisFull,
+    porter,
     messageKit,
     ritualId,
     context,

--- a/packages/taco/src/taco.ts
+++ b/packages/taco/src/taco.ts
@@ -140,7 +140,9 @@ export const decrypt = async (
   context?: ConditionContext,
   porterUris?: string[],
 ): Promise<Uint8Array> => {
-  const porterUrisFull: string[] = porterUris ? porterUris : await getPorterUris(domain);
+  const porterUrisFull: string[] = porterUris
+    ? porterUris
+    : await getPorterUris(domain);
 
   const ritualId = await DkgCoordinatorAgent.getRitualIdFromPublicKey(
     provider,

--- a/packages/taco/src/taco.ts
+++ b/packages/taco/src/taco.ts
@@ -155,7 +155,6 @@ export const decrypt = async (
     domain,
     messageKit.acp.publicKey,
   );
-  const ritual = await DkgClient.getActiveRitual(provider, domain, ritualId);
   const authProviders: AuthProviders = authProvider
     ? {
         [EIP4361_AUTH_METHOD]: authProvider,
@@ -167,8 +166,6 @@ export const decrypt = async (
     porterUrisFull,
     messageKit,
     ritualId,
-    ritual.sharesNum,
-    ritual.threshold,
     authProviders,
     customParameters,
   );
@@ -200,6 +197,7 @@ export const isAuthorized = async (
     messageKit,
   );
 
+// TODO is this still valid and actually needed? should we remove this?
 export const registerEncrypters = async (
   provider: ethers.providers.Provider,
   signer: ethers.Signer,

--- a/packages/taco/src/tdec.ts
+++ b/packages/taco/src/tdec.ts
@@ -61,7 +61,7 @@ export const encryptMessage = async (
 export const retrieveAndDecrypt = async (
   provider: ethers.providers.Provider,
   domain: Domain,
-  porterUris: string[],
+  porter: PorterClient,
   thresholdMessageKit: ThresholdMessageKit,
   ritualId: number,
   context?: ConditionContext,
@@ -69,7 +69,7 @@ export const retrieveAndDecrypt = async (
   const decryptionShares = await retrieve(
     provider,
     domain,
-    porterUris,
+    porter,
     thresholdMessageKit,
     ritualId,
     context,
@@ -82,7 +82,7 @@ export const retrieveAndDecrypt = async (
 const retrieve = async (
   provider: ethers.providers.Provider,
   domain: Domain,
-  porterUris: string[],
+  porter: PorterClient,
   thresholdMessageKit: ThresholdMessageKit,
   ritualId: number,
   context?: ConditionContext,
@@ -106,7 +106,6 @@ const retrieve = async (
     thresholdMessageKit,
   );
 
-  const porter = new PorterClient(porterUris);
   const { encryptedResponses, errors } = await porter.tacoDecrypt(
     encryptedRequests,
     ritual.threshold,

--- a/packages/taco/test/conditions/conditions.test.ts
+++ b/packages/taco/test/conditions/conditions.test.ts
@@ -1,4 +1,5 @@
 import { ChainId } from '@nucypher/shared';
+import { AuthProvider, USER_ADDRESS_PARAM_DEFAULT } from '@nucypher/taco-auth';
 import { fakeAuthProviders } from '@nucypher/test-utils';
 import { beforeAll, describe, expect, it } from 'vitest';
 
@@ -8,8 +9,10 @@ import { SUPPORTED_CHAIN_IDS } from '../../src/conditions/const';
 import { ConditionContext } from '../../src/conditions/context';
 
 describe('conditions', () => {
+  let authProviders: Record<string, AuthProvider>;
   beforeAll(async () => {
     await initialize();
+    authProviders = await fakeAuthProviders();
   });
 
   it('creates a complex condition with custom parameters', async () => {
@@ -37,11 +40,13 @@ describe('conditions', () => {
     expect(condition).toBeDefined();
     expect(condition.requiresAuthentication()).toBeTruthy();
 
-    const context = new ConditionContext(
-      condition,
-      { ':time': 100 },
-      fakeAuthProviders(),
+    const context = new ConditionContext(condition);
+    context.addCustomContextParameterValues({ ':time': 100 });
+    context.addAuthProvider(
+      USER_ADDRESS_PARAM_DEFAULT,
+      authProviders[USER_ADDRESS_PARAM_DEFAULT],
     );
+
     expect(context).toBeDefined();
 
     const asObj = await context.toContextParameters();

--- a/packages/taco/test/conditions/context.test.ts
+++ b/packages/taco/test/conditions/context.test.ts
@@ -5,6 +5,7 @@ import {
   EIP4361AuthProvider,
   SingleSignOnEIP4361AuthProvider,
   USER_ADDRESS_PARAM_DEFAULT,
+  USER_ADDRESS_PARAM_EXTERNAL_EIP4361,
 } from '@nucypher/taco-auth';
 import {
   fakeAuthProviders,

--- a/packages/taco/test/conditions/context.test.ts
+++ b/packages/taco/test/conditions/context.test.ts
@@ -22,13 +22,10 @@ import {
 } from '../../src/conditions/base/contract';
 import { RpcCondition } from '../../src/conditions/base/rpc';
 import {
-  RESERVED_CONTEXT_PARAMS,
-  USER_ADDRESS_PARAM_EXTERNAL_EIP4361,
-} from '../../src/conditions/const';
-import {
   ConditionContext,
   CustomContextParam,
 } from '../../src/conditions/context';
+import { RESERVED_CONTEXT_PARAMS } from '../../src/conditions/context/context';
 import {
   paramOrContextParamSchema,
   ReturnValueTestProps,

--- a/packages/taco/test/conditions/context.test.ts
+++ b/packages/taco/test/conditions/context.test.ts
@@ -82,7 +82,9 @@ describe('context', () => {
     describe('custom parameters', () => {
       it('detects when a custom parameter is requested', () => {
         const conditionContext = new ConditionContext(contractCondition);
-        expect(conditionContext.requestedParameters).toContain(customParamKey);
+        expect(conditionContext.requestedContextParameters).toContain(
+          customParamKey,
+        );
       });
 
       it('serializes bytes as hex strings', async () => {
@@ -232,10 +234,12 @@ describe('context', () => {
       };
 
       it('handles both custom and auth context parameters', () => {
-        const requestedParams = new ConditionContext(contractCondition)
-          .requestedParameters;
-        expect(requestedParams).not.toContain(USER_ADDRESS_PARAM_DEFAULT);
-        expect(requestedParams).toContain(customParamKey);
+        const requestedContextParams = new ConditionContext(contractCondition)
+          .requestedContextParameters;
+        expect(requestedContextParams).not.toContain(
+          USER_ADDRESS_PARAM_DEFAULT,
+        );
+        expect(requestedContextParams).toContain(customParamKey);
       });
 
       it('rejects on a missing custom parameter ', async () => {

--- a/packages/taco/test/conditions/context.test.ts
+++ b/packages/taco/test/conditions/context.test.ts
@@ -354,6 +354,62 @@ describe('No authentication provider', () => {
     });
   });
 
+  it('rejects auth provider for not applicable context param', () => {
+    const conditionObj = {
+      ...testContractConditionObj,
+      returnValueTest: {
+        ...testReturnValueTest,
+        value: ':myParam',
+      },
+    };
+    const condition = new ContractCondition(conditionObj);
+    const conditionContext = new ConditionContext(condition);
+    expect(() =>
+      conditionContext.addAuthProvider(
+        ':myParam',
+        authProviders[USER_ADDRESS_PARAM_DEFAULT],
+      ),
+    ).toThrow('AuthProvider not necessary for context parameter: :myParam');
+  });
+
+  it('rejects invalid auth provider for :userAddress', () => {
+    const conditionObj = {
+      ...testContractConditionObj,
+      returnValueTest: {
+        ...testReturnValueTest,
+        value: USER_ADDRESS_PARAM_DEFAULT,
+      },
+    };
+    const condition = new ContractCondition(conditionObj);
+    const conditionContext = new ConditionContext(condition);
+    expect(() =>
+      conditionContext.addAuthProvider(
+        USER_ADDRESS_PARAM_DEFAULT,
+        authProviders[USER_ADDRESS_PARAM_EXTERNAL_EIP4361],
+      ),
+    ).toThrow(`Invalid AuthProvider type for ${USER_ADDRESS_PARAM_DEFAULT}`);
+  });
+
+  it('rejects invalid auth provider for :userAddressExternalEIP4361', () => {
+    const conditionObj = {
+      ...testContractConditionObj,
+      returnValueTest: {
+        ...testReturnValueTest,
+        value: USER_ADDRESS_PARAM_EXTERNAL_EIP4361,
+      },
+    };
+    const condition = new ContractCondition(conditionObj);
+    const conditionContext = new ConditionContext(condition);
+    expect(() =>
+      conditionContext.addAuthProvider(
+        USER_ADDRESS_PARAM_EXTERNAL_EIP4361,
+        authProviders[USER_ADDRESS_PARAM_DEFAULT],
+      ),
+    ).toThrow(
+      `Invalid AuthProvider type for ${USER_ADDRESS_PARAM_EXTERNAL_EIP4361}`,
+    );
+  });
+
   it('it supports just one provider at a time', async () => {
     const conditionObj = {
       ...testContractConditionObj,

--- a/packages/taco/test/taco.test.ts
+++ b/packages/taco/test/taco.test.ts
@@ -132,7 +132,7 @@ describe('taco', () => {
     expect(getFinalizedRitualSpy).toHaveBeenCalled();
 
     const conditionContext = ConditionContext.fromMessageKit(messageKit);
-    const requestedParameters = conditionContext.requestedParameters;
+    const requestedParameters = conditionContext.requestedContextParameters;
     expect(requestedParameters).toEqual(
       new Set([customParamKey, USER_ADDRESS_PARAM_DEFAULT]),
     );

--- a/packages/taco/test/taco.test.ts
+++ b/packages/taco/test/taco.test.ts
@@ -21,6 +21,7 @@ import { beforeAll, describe, expect, it } from 'vitest';
 
 import * as taco from '../src';
 import { conditions, domains, toBytes } from '../src';
+import { ConditionContext } from '../src/conditions/context';
 
 import {
   fakeDkgRitual,
@@ -88,11 +89,13 @@ describe('taco', () => {
       signer,
       TEST_SIWE_PARAMS,
     );
+    const conditionContext = ConditionContext.fromMessageKit(messageKit);
+    conditionContext.addAuthProvider(USER_ADDRESS_PARAM_DEFAULT, authProvider);
     const decryptedMessage = await taco.decrypt(
       provider,
       domains.DEVNET,
       messageKit,
-      authProvider,
+      conditionContext,
       [fakePorterUri],
     );
     expect(decryptedMessage).toEqual(toBytes(message));
@@ -128,10 +131,8 @@ describe('taco', () => {
     );
     expect(getFinalizedRitualSpy).toHaveBeenCalled();
 
-    const requestedParameters =
-      taco.conditions.context.ConditionContext.requestedContextParameters(
-        messageKit,
-      );
+    const conditionContext = ConditionContext.fromMessageKit(messageKit);
+    const requestedParameters = conditionContext.requestedParameters;
     expect(requestedParameters).toEqual(
       new Set([customParamKey, USER_ADDRESS_PARAM_DEFAULT]),
     );

--- a/packages/test-utils/src/utils.ts
+++ b/packages/test-utils/src/utils.ts
@@ -152,9 +152,11 @@ export const fakeUrsulas = (n = 4): Ursula[] =>
 export const mockGetUrsulas = (
   ursulas: Ursula[] = fakeUrsulas(),
 ): SpyInstance => {
-  return vi.spyOn(PorterClient.prototype, 'getUrsulas').mockImplementation(async () => {
-    return Promise.resolve(ursulas);
-  });
+  return vi
+    .spyOn(PorterClient.prototype, 'getUrsulas')
+    .mockImplementation(async () => {
+      return Promise.resolve(ursulas);
+    });
 };
 
 const fakeCFragResponse = (

--- a/packages/test-utils/src/utils.ts
+++ b/packages/test-utils/src/utils.ts
@@ -37,7 +37,11 @@ import {
   Ursula,
   zip,
 } from '@nucypher/shared';
-import { EIP4361_AUTH_METHOD, EIP4361AuthProvider } from '@nucypher/taco-auth';
+import {
+  EIP4361AuthProvider,
+  SingleSignOnEIP4361AuthProvider,
+  USER_ADDRESS_PARAM_DEFAULT,
+} from '@nucypher/taco-auth';
 import { ethers, providers, Wallet } from 'ethers';
 import { expect, SpyInstance, vi } from 'vitest';
 
@@ -83,13 +87,11 @@ export const fakeSigner = (
   } as unknown as ethers.providers.JsonRpcSigner;
 };
 
-export const fakeAuthProviders = () => {
+export const fakeAuthProviders = async () => {
   return {
-    [EIP4361_AUTH_METHOD]: new EIP4361AuthProvider(
-      fakeProvider(),
-      fakeSigner(),
-      TEST_SIWE_PARAMS,
-    ),
+    [USER_ADDRESS_PARAM_DEFAULT]: fakeEIP4351AuthProvider(),
+    [':userAddressExternalEIP4361']:
+      await fakeSingleSignOnEIP4361AuthProvider(),
   };
 };
 
@@ -109,6 +111,26 @@ export const fakeProvider = (
     ...fakeProvider,
     getSigner: () => fakeSignerWithProvider,
   } as unknown as ethers.providers.Web3Provider;
+};
+
+const fakeEIP4351AuthProvider = () => {
+  return new EIP4361AuthProvider(
+    fakeProvider(),
+    fakeSigner(),
+    TEST_SIWE_PARAMS,
+  );
+};
+
+const fakeSingleSignOnEIP4361AuthProvider = async () => {
+  const message =
+    'localhost wants you to sign in with your Ethereum account:\n0x924c255297BF9032583dF6E06a8633dc720aB52D\n\nSign-In With Ethereum Example Statement\n\nURI: http://localhost:3000\nVersion: 1\nChain ID: 1234\nNonce: bTyXgcQxn2htgkjJn\nIssued At: 2024-07-18T16:53:39.093516Z';
+  const signature =
+    '0x22cc163b9c37cf425997b76ebafd44a0d68043d0dc9a1dbf823e78c320924476644f28abcf0974d54b8604eff8a62a51559994537d4b8a85cdee977e02ee98921b';
+
+  return SingleSignOnEIP4361AuthProvider.fromExistingSiweInfo(
+    message,
+    signature,
+  );
 };
 
 const genChecksumAddress = (i: number): ChecksumAddress =>


### PR DESCRIPTION
**Type of PR:**

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:**

- [ ] 1
- [x] 2
- [ ] 3

**What this does:**
- Rework of decryption API to use `ConditionContext` instead of splitting up params for authProvider and customParameters.
- Allow `ConditionContext` to be populated by developers with authProviders and customParameters before being used for decryption
- Reduce parameters used in calls for decryption -> retrieve flow. Instead only obtain the ritual from the ritual id when the values are actually needed.


The updated use of the code will look like the following:

1. Create condition context from message kit:
```typescript
const conditionContext = conditions.context.ConditionContext.fromMessageKit(messageKit);
```

2. Add any required auth provider(s):
    * Add auth provider for `:userAddress`, if necessary:
    ```typescript
    const authProvider = new EIP4361AuthProvider(web3Provider, web3Provider.getSigner());
    conditionContext.addAuthProvider(USER_ADDRESS_PARAM_DEFAULT, authProvider);
    ```

    * Add auth provider for `:userAddressExternalEIP4361`, if necessary:
    ```typescript
    const singleSignOnEIP4361AuthProvider = await SingleSignOnEIP4361AuthProvider.fromExistingSiweInfo(messageStr, 
    signature);
    conditionContext.addAuthProvider(USER_ADDRESS_PARAM_EXTERNAL_EIP4361, authProvider);
    ```

3. Add any required custom context variables, if necessary:
```typescript
const conditionContext = conditions.context.ConditionContext.fromMessageKit(messageKit);
conditionContext.addCustomContextParameterValues({
    ":myCustomValue1": value_1,
    ":myCustomVallue2": value_2,
    ...
});
```

4. Call decrypt
```typescript
const decryptedMessage = await decrypt(web3Provider, domain, messageKit, conditionContext);
```

---

Additionally, developers can also better query what parameters are needed for a condition in a message kit. This helps when apps have various permutations of conditions that they use, which include different parameters:
```typescript
const conditionContext = conditions.context.ConditionContext.fromMessageKit(messageKit);
requestedContextParameters = conditionContext.requestedContextParameters  // set of context variables required for underlying condition
// Devs can check for specific context parameters or loop over the set and populate context variables appropriately.
```

**Issues fixed/closed:**
> - Fixes #...

- Closes https://github.com/nucypher/sprints/issues/44

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on?
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
