### PR TITLE
Added JSONPath syntactic validation

### DIFF
--- a/packages/taco/package.json
+++ b/packages/taco/package.json
@@ -43,13 +43,11 @@
     "@nucypher/shared": "workspace:*",
     "@nucypher/taco-auth": "workspace:*",
     "ethers": "*",
-    "jsonpath": "^1.1.1",
     "semver": "^7.5.2",
     "zod": "*"
   },
   "devDependencies": {
     "@nucypher/test-utils": "workspace:*",
-    "@types/jsonpath": "^0.2.4",
     "@types/semver": "^7.5.6"
   },
   "engines": {

--- a/packages/taco/package.json
+++ b/packages/taco/package.json
@@ -39,6 +39,7 @@
     "typedoc": "typedoc"
   },
   "dependencies": {
+    "@astronautlabs/jsonpath": "^1.1.2",
     "@nucypher/nucypher-core": "*",
     "@nucypher/shared": "workspace:*",
     "@nucypher/taco-auth": "workspace:*",

--- a/packages/taco/package.json
+++ b/packages/taco/package.json
@@ -43,11 +43,13 @@
     "@nucypher/shared": "workspace:*",
     "@nucypher/taco-auth": "workspace:*",
     "ethers": "*",
+    "jsonpath": "^1.1.1",
     "semver": "^7.5.2",
     "zod": "*"
   },
   "devDependencies": {
     "@nucypher/test-utils": "workspace:*",
+    "@types/jsonpath": "^0.2.4",
     "@types/semver": "^7.5.6"
   },
   "engines": {

--- a/packages/taco/src/conditions/base/json-api.ts
+++ b/packages/taco/src/conditions/base/json-api.ts
@@ -1,10 +1,10 @@
-import { parse } from "jsonpath";
-import { z } from "zod";
+import { parse } from 'jsonpath';
+import { z } from 'zod';
 
-import { Condition } from "../condition";
-import { OmitConditionType, returnValueTestSchema } from "../shared";
+import { Condition } from '../condition';
+import { OmitConditionType, returnValueTestSchema } from '../shared';
 
-export const JsonApiConditionType = "json-api";
+export const JsonApiConditionType = 'json-api';
 
 const validateJSONPath = (jsonPath: string): boolean => {
   try {
@@ -18,7 +18,7 @@ const validateJSONPath = (jsonPath: string): boolean => {
 export const jsonPathSchema = z
   .string()
   .refine((val) => validateJSONPath(val), {
-    message: "Invalid JSONPath expression",
+    message: 'Invalid JSONPath expression',
   });
 
 export const JsonApiConditionSchema = z.object({

--- a/packages/taco/src/conditions/base/json-api.ts
+++ b/packages/taco/src/conditions/base/json-api.ts
@@ -1,18 +1,31 @@
-import { z } from 'zod';
+import { parse } from "jsonpath";
+import { z } from "zod";
 
-import { Condition } from '../condition';
-import {
-  OmitConditionType,
-  returnValueTestSchema,
-} from '../shared';
+import { Condition } from "../condition";
+import { OmitConditionType, returnValueTestSchema } from "../shared";
 
-export const JsonApiConditionType = 'json-api';
+export const JsonApiConditionType = "json-api";
+
+const validateJSONPath = (jsonPath: string): boolean => {
+  try {
+    parse(jsonPath);
+    return true;
+  } catch (error) {
+    return false;
+  }
+};
+
+export const jsonPathSchema = z
+  .string()
+  .refine((val) => validateJSONPath(val), {
+    message: "Invalid JSONPath expression",
+  });
 
 export const JsonApiConditionSchema = z.object({
   conditionType: z.literal(JsonApiConditionType).default(JsonApiConditionType),
   endpoint: z.string().url(),
   parameters: z.record(z.string(), z.unknown()).optional(),
-  query: z.string().optional(),
+  query: jsonPathSchema.optional(),
   returnValueTest: returnValueTestSchema, // Update to allow multiple return values after expanding supported methods
 });
 

--- a/packages/taco/src/conditions/base/json-api.ts
+++ b/packages/taco/src/conditions/base/json-api.ts
@@ -1,4 +1,3 @@
-import { parse } from 'jsonpath';
 import { z } from 'zod';
 
 import { Condition } from '../condition';
@@ -6,14 +5,68 @@ import { OmitConditionType, returnValueTestSchema } from '../shared';
 
 export const JsonApiConditionType = 'json-api';
 
-const validateJSONPath = (jsonPath: string): boolean => {
-  try {
-    parse(jsonPath);
-    return true;
-  } catch (error) {
-    return false;
+function tokenize(expression: string): string[] {
+  const regex =
+    /(\$|@|\.\.|\.|[[\]]|\?|\(|\)|==|!=|<=|>=|<|>|&&|\|\||[a-zA-Z_][\w]*|\d+|'[^']*')/g;
+  return expression.match(regex) || [];
+}
+
+function validateJSONPath(expression: string): boolean {
+  const tokens = tokenize(expression);
+
+  let depth = 0;
+  let inBracket = false;
+  let inFilter = false;
+  let lastTokenWasCloseBracket = false;
+
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i];
+
+    if (token === '$' && i !== 0) return false; // $ only at the beginning
+    if (token === '@' && !inFilter) return false; // @ only in filters
+
+    if (token === '[') {
+      if (lastTokenWasCloseBracket) return false; // Don't allow [...][]
+      depth++;
+      inBracket = true;
+      lastTokenWasCloseBracket = false;
+    } else if (token === ']') {
+      if (depth === 0) return false;
+      depth--;
+      inBracket = false;
+      lastTokenWasCloseBracket = true;
+    } else {
+      lastTokenWasCloseBracket = false;
+    }
+
+    if (token === '?') {
+      if (!inBracket) return false;
+      inFilter = true;
+    } else if (token === '(') {
+      if (!inFilter) return false;
+    } else if (token === ')') {
+      if (!inFilter) return false;
+      inFilter = false;
+    }
+
+    // Check for valid operators in filters
+    if (
+      inFilter &&
+      ['==', '!=', '<', '<=', '>', '>=', '&&', '||'].includes(token)
+    ) {
+      if (i === 0 || i === tokens.length - 1) return false;
+    }
+
+    // Check that there are no two consecutive dots outside brackets
+    if (token === '.' && i > 0 && tokens[i - 1] === '.' && !inBracket)
+      return false;
   }
-};
+
+  if (depth !== 0) return false; // Unclosed brackets
+  if (inFilter) return false; // Unclosed filter
+
+  return true;
+}
 
 export const jsonPathSchema = z
   .string()

--- a/packages/taco/test/conditions/base/json-api.test.ts
+++ b/packages/taco/test/conditions/base/json-api.test.ts
@@ -7,18 +7,21 @@ describe('JSONPath Validation', () => {
     const invalidPath = '$.store.book[?(@.price < ]';
     const result = jsonPathSchema.safeParse(invalidPath);
     expect(result.success).toBe(false);
+    expect(result.error!.errors[0].message).toBe('Invalid JSONPath expression');
   });
 
   it('Invalid JSONPath: Incorrect use of brackets', () => {
     const invalidPath = '$[store][book]';
     const result = jsonPathSchema.safeParse(invalidPath);
     expect(result.success).toBe(false);
+    expect(result.error!.errors[0].message).toBe('Invalid JSONPath expression');
   });
 
   it('Invalid JSONPath: Unclosed wildcard asterisk', () => {
     const invalidPath = '$.store.book[*';
     const result = jsonPathSchema.safeParse(invalidPath);
     expect(result.success).toBe(false);
+    expect(result.error!.errors[0].message).toBe('Invalid JSONPath expression');
   });
 
   it('Valid JSONPath expression', () => {

--- a/packages/taco/test/conditions/base/json-api.test.ts
+++ b/packages/taco/test/conditions/base/json-api.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+
+import { jsonPathSchema } from '../../../src/conditions/base/json-api';
+
+describe('JSONPath Validation', () => {
+  it('Invalid JSONPath: Incomplete filter expression', () => {
+    const invalidPath = '$.store.book[?(@.price < ]';
+    const result = jsonPathSchema.safeParse(invalidPath);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.errors[0].message).toBe(
+        'Invalid JSONPath expression',
+      );
+    }
+  });
+
+  it('Invalid JSONPath: Incorrect use of brackets', () => {
+    const invalidPath = '$[store][book]';
+    const result = jsonPathSchema.safeParse(invalidPath);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.errors[0].message).toBe(
+        'Invalid JSONPath expression',
+      );
+    }
+  });
+
+  it('Invalid JSONPath: Unclosed wildcard asterisk', () => {
+    const invalidPath = '$.store.book[*';
+    const result = jsonPathSchema.safeParse(invalidPath);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.errors[0].message).toBe(
+        'Invalid JSONPath expression',
+      );
+    }
+  });
+
+  it('Valid JSONPath expression', () => {
+    const validPath = '$.store.book[?(@.price < 10)]';
+    const result = jsonPathSchema.safeParse(validPath);
+    expect(result.success).toBe(true);
+  });
+
+  it('Valid JSONPath with correct quotes', () => {
+    const validPath = "$.store['book[?(@.price < ]']";
+    const result = jsonPathSchema.safeParse(validPath);
+    expect(result.success).toBe(true);
+  });
+
+  it('Valid JSONPath with correct wildcard', () => {
+    const validPath = '$.store.book[*]';
+    const result = jsonPathSchema.safeParse(validPath);
+    expect(result.success).toBe(true);
+  });
+});

--- a/packages/taco/test/conditions/base/json-api.test.ts
+++ b/packages/taco/test/conditions/base/json-api.test.ts
@@ -7,33 +7,18 @@ describe('JSONPath Validation', () => {
     const invalidPath = '$.store.book[?(@.price < ]';
     const result = jsonPathSchema.safeParse(invalidPath);
     expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(result.error.errors[0].message).toBe(
-        'Invalid JSONPath expression',
-      );
-    }
   });
 
   it('Invalid JSONPath: Incorrect use of brackets', () => {
     const invalidPath = '$[store][book]';
     const result = jsonPathSchema.safeParse(invalidPath);
     expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(result.error.errors[0].message).toBe(
-        'Invalid JSONPath expression',
-      );
-    }
   });
 
   it('Invalid JSONPath: Unclosed wildcard asterisk', () => {
     const invalidPath = '$.store.book[*';
     const result = jsonPathSchema.safeParse(invalidPath);
     expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(result.error.errors[0].message).toBe(
-        'Invalid JSONPath expression',
-      );
-    }
   });
 
   it('Valid JSONPath expression', () => {

--- a/packages/taco/test/conditions/base/json.test.ts
+++ b/packages/taco/test/conditions/base/json.test.ts
@@ -25,7 +25,10 @@ describe('JsonApiCondition', () => {
         endpoint: 'not-a-url',
       };
 
-      const result = JsonApiCondition.validate(JsonApiConditionSchema, badJsonApiObj);
+      const result = JsonApiCondition.validate(
+        JsonApiConditionSchema,
+        badJsonApiObj,
+      );
 
       expect(result.error).toBeDefined();
       expect(result.data).toBeUndefined();
@@ -35,26 +38,26 @@ describe('JsonApiCondition', () => {
         },
       });
     });
-    
+
     describe('parameters', () => {
       it('accepts conditions without query path', () => {
-        const { query, ...noQueryObj} = testJsonApiConditionObj;
+        const { query, ...noQueryObj } = testJsonApiConditionObj;
         const result = JsonApiCondition.validate(
           JsonApiConditionSchema,
-          noQueryObj
+          noQueryObj,
         );
-  
+
         expect(result.error).toBeUndefined();
         expect(result.data).toEqual(noQueryObj);
       });
 
       it('accepts conditions without parameters', () => {
-        const { query, ...noParamsObj} = testJsonApiConditionObj;
+        const { query, ...noParamsObj } = testJsonApiConditionObj;
         const result = JsonApiCondition.validate(
           JsonApiConditionSchema,
-          noParamsObj
+          noParamsObj,
         );
-  
+
         expect(result.error).toBeUndefined();
         expect(result.data).toEqual(noParamsObj);
       });

--- a/packages/taco/test/conditions/condition-expr.test.ts
+++ b/packages/taco/test/conditions/condition-expr.test.ts
@@ -406,17 +406,20 @@ describe('condition set', () => {
 
     it('json api condition serialization', () => {
       const conditionExpr = new ConditionExpression(jsonApiCondition);
-  
+
       const conditionExprJson = conditionExpr.toJson();
       expect(conditionExprJson).toBeDefined();
       expect(conditionExprJson).toContain('endpoint');
-      expect(conditionExprJson).toContain('https://_this_would_totally_fail.com');
+      expect(conditionExprJson).toContain(
+        'https://_this_would_totally_fail.com',
+      );
       expect(conditionExprJson).toContain('parameters');
       expect(conditionExprJson).toContain('query');
       expect(conditionExprJson).toContain('$.ethereum.usd');
       expect(conditionExprJson).toContain('returnValueTest');
-  
-      const conditionExprFromJson = ConditionExpression.fromJSON(conditionExprJson);
+
+      const conditionExprFromJson =
+        ConditionExpression.fromJSON(conditionExprJson);
       expect(conditionExprFromJson).toBeDefined();
       expect(conditionExprFromJson.condition).toBeInstanceOf(JsonApiCondition);
     });

--- a/packages/taco/test/test-utils.ts
+++ b/packages/taco/test/test-utils.ts
@@ -39,10 +39,7 @@ import {
   ContractConditionType,
   FunctionAbiProps,
 } from '../src/conditions/base/contract';
-import {
-  JsonApiConditionProps,
-  JsonApiConditionType
-} from '../src/conditions/base/json-api';
+import { JsonApiConditionType } from '../src/conditions/base/json-api';
 import {
   RpcConditionProps,
   RpcConditionType,
@@ -230,8 +227,8 @@ export const testJsonApiConditionObj = {
   conditionType: JsonApiConditionType,
   endpoint: 'https://_this_would_totally_fail.com',
   parameters: {
-    'ids': 'ethereum',
-    'vs_currencies': 'usd',
+    ids: 'ethereum',
+    vs_currencies: 'usd',
   },
   query: '$.ethereum.usd',
   returnValueTest: testReturnValueTest,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -552,9 +552,6 @@ importers:
       ethers:
         specifier: '*'
         version: 5.7.2(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-      jsonpath:
-        specifier: ^1.1.1
-        version: 1.1.1
       semver:
         specifier: ^7.5.2
         version: 7.6.2
@@ -565,9 +562,6 @@ importers:
       '@nucypher/test-utils':
         specifier: workspace:*
         version: link:../test-utils
-      '@types/jsonpath':
-        specifier: ^0.2.4
-        version: 0.2.4
       '@types/semver':
         specifier: ^7.5.6
         version: 7.5.8
@@ -2620,9 +2614,6 @@ packages:
 
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
-
-  '@types/jsonpath@0.2.4':
-    resolution: {integrity: sha512-K3hxB8Blw0qgW6ExKgMbXQv2UPZBoE2GqLpVY+yr7nMD2Pq86lsuIzyAaiQ7eMqFL5B6di6pxSkogLJEyEHoGA==}
 
   '@types/keyv@3.1.4':
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
@@ -11555,8 +11546,6 @@ snapshots:
   '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
-
-  '@types/jsonpath@0.2.4': {}
 
   '@types/keyv@3.1.4':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -552,6 +552,9 @@ importers:
       ethers:
         specifier: '*'
         version: 5.7.2(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      jsonpath:
+        specifier: ^1.1.1
+        version: 1.1.1
       semver:
         specifier: ^7.5.2
         version: 7.6.2
@@ -562,6 +565,9 @@ importers:
       '@nucypher/test-utils':
         specifier: workspace:*
         version: link:../test-utils
+      '@types/jsonpath':
+        specifier: ^0.2.4
+        version: 0.2.4
       '@types/semver':
         specifier: ^7.5.6
         version: 7.5.8
@@ -2614,6 +2620,9 @@ packages:
 
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
+
+  '@types/jsonpath@0.2.4':
+    resolution: {integrity: sha512-K3hxB8Blw0qgW6ExKgMbXQv2UPZBoE2GqLpVY+yr7nMD2Pq86lsuIzyAaiQ7eMqFL5B6di6pxSkogLJEyEHoGA==}
 
   '@types/keyv@3.1.4':
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
@@ -11546,6 +11555,8 @@ snapshots:
   '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
+
+  '@types/jsonpath@0.2.4': {}
 
   '@types/keyv@3.1.4':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -540,6 +540,9 @@ importers:
 
   packages/taco:
     dependencies:
+      '@astronautlabs/jsonpath':
+        specifier: ^1.1.2
+        version: 1.1.2
       '@nucypher/nucypher-core':
         specifier: ^0.14.5
         version: 0.14.5
@@ -633,6 +636,9 @@ packages:
   '@aptos-labs/ts-sdk@1.16.0':
     resolution: {integrity: sha512-NqJDx39sHN0o7BpxpQzishoZjGBzvXqSVxO+bRm6OPP/Oe+Kb51R5x8dWvW9i3amO3QNdocg/p4jFRCwzqy2Gg==}
     engines: {node: '>=11.0.0'}
+
+  '@astronautlabs/jsonpath@1.1.2':
+    resolution: {integrity: sha512-FqL/muoreH7iltYC1EB5Tvox5E8NSOOPGkgns4G+qxRKl6k5dxEVljUjB5NcKESzkqwnUqWjSZkL61XGYOuV+A==}
 
   '@babel/code-frame@7.24.6':
     resolution: {integrity: sha512-ZJhac6FkEd1yhG2AHOmfcXG4ceoLltoCVJjN5XsWN9BifBQr+cHJbWi0h68HZuSORq+3WtJ2z0hwF2NG1b5kcA==}
@@ -9044,6 +9050,10 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
+  '@astronautlabs/jsonpath@1.1.2':
+    dependencies:
+      static-eval: 2.0.2
+
   '@babel/code-frame@7.24.6':
     dependencies:
       '@babel/highlight': 7.24.6
@@ -13986,8 +13996,8 @@ snapshots:
       '@typescript-eslint/parser': 6.21.0(eslint@8.56.0)(typescript@5.4.5)
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.56.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.56.0))(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.56.0)
       eslint-plugin-react: 7.34.1(eslint@8.56.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.56.0)
@@ -14058,13 +14068,13 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.56.0):
+  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.56.0))(eslint@8.56.0):
     dependencies:
       debug: 4.3.5
       enhanced-resolve: 5.17.1
       eslint: 8.56.0
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.56.0))(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.56.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.5
       is-core-module: 2.13.1
@@ -14096,24 +14106,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.56.0))(eslint@8.56.0):
+  eslint-module-utils@2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 6.21.0(eslint@8.56.0)(typescript@5.4.5)
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.56.0)
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint@8.56.0):
-    dependencies:
-      debug: 3.2.7
-    optionalDependencies:
-      '@typescript-eslint/parser': 6.21.0(eslint@8.57.0)(typescript@5.4.5)
-      eslint: 8.56.0
-      eslint-import-resolver-node: 0.3.9
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.56.0))(eslint@8.56.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -14195,7 +14195,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.56.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0):
     dependencies:
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5
@@ -14205,7 +14205,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint@8.56.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
       hasown: 2.0.2
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -14216,7 +14216,7 @@ snapshots:
       semver: 6.3.1
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 6.21.0(eslint@8.57.0)(typescript@5.4.5)
+      '@typescript-eslint/parser': 6.21.0(eslint@8.56.0)(typescript@5.4.5)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack


### PR DESCRIPTION
**Type of PR:**

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [X] Other

**Required reviews:**

- [ ] 1
- [ ] 2
- [x] 3

**What this does:**

> Added JSONPath syntactic validation

Related to https://github.com/nucypher/taco-web/pull/550/files#r1696888086


**Issues fixed/closed:**

> - Fixes #559 

**Why it's needed:**

> Explain how this PR fits in the greater context of the NuCypher Network. E.g.,
> if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**

This depends on the PR #550
With the integrated PR #550 my approach is to use it in the following way

```
export const JsonApiConditionSchema = z.object({
  conditionType: z.literal(JsonApiConditionType).default(JsonApiConditionType),
  endpoint: z.string().url(),
  parameters: z.record(z.string(), z.unknown()).optional(),
  query: jsonPathSchema.optional(),
  returnValueTest: returnValueTestSchema, // Update to allow multiple return values after expanding supported methods
});

```
