### PR TITLE
Prevent perpetual use of  expired auth signature; remove superfluous API functions

### DIFF
--- a/examples/taco/nodejs/src/index.ts
+++ b/examples/taco/nodejs/src/index.ts
@@ -10,7 +10,6 @@ import {
   encrypt,
   fromBytes,
   initialize,
-  isAuthorized,
   toBytes,
   toHexString,
 } from '@nucypher/taco';
@@ -80,18 +79,6 @@ const encryptToBytes = async (messageString: string) => {
     ritualId,
     encryptorSigner,
   );
-
-  // Note: Not actually needed but used by CI for checking contract compatibility.
-  // Calling it after the encryption because we need material from messageKit.
-  const isEncryptorAuthenticated = await isAuthorized(
-    provider,
-    domain,
-    messageKit,
-    ritualId,
-  );
-  if (!isEncryptorAuthenticated) {
-    throw new Error('Not authorized');
-  }
 
   return messageKit.toBytes();
 };

--- a/packages/pre/test/acceptance/alice-grants.test.ts
+++ b/packages/pre/test/acceptance/alice-grants.test.ts
@@ -10,7 +10,6 @@ import {
   bytesEqual,
   fakePorterUri,
   fakeProvider,
-  fakeSigner,
   fakeUrsulas,
   fromBytes,
   mockGetUrsulas,
@@ -70,9 +69,10 @@ describe('story: alice shares message with bob through policy', () => {
       startDate,
       endDate,
     };
+    const provider = fakeProvider();
     policy = await alice.grant(
-      fakeProvider(),
-      fakeSigner(),
+      provider,
+      provider.getSigner(),
       domains.DEVNET,
       fakePorterUri,
       policyParams,

--- a/packages/pre/test/acceptance/delay-enact.test.ts
+++ b/packages/pre/test/acceptance/delay-enact.test.ts
@@ -2,7 +2,6 @@ import {
   bytesEqual,
   fakePorterUri,
   fakeProvider,
-  fakeSigner,
   fakeUrsulas,
   mockGetUrsulas,
 } from '@nucypher/test-utils';
@@ -61,7 +60,7 @@ describe('story: alice creates a policy but someone else enacts it', () => {
 
       const enacted = await preEnactedPolicy.enact(
         provider,
-        fakeSigner(),
+        provider.getSigner(),
         domains.DEVNET,
       );
       expect(enacted.txHash).toBeDefined();

--- a/packages/taco-auth/src/storage.ts
+++ b/packages/taco-auth/src/storage.ts
@@ -4,6 +4,8 @@ interface IStorage {
   getItem(key: string): string | null;
 
   setItem(key: string, value: string): void;
+
+  removeItem(key: string): void;
 }
 
 class BrowserStorage implements IStorage {
@@ -13,6 +15,10 @@ class BrowserStorage implements IStorage {
 
   public setItem(key: string, value: string): void {
     localStorage.setItem(key, value);
+  }
+
+  public removeItem(key: string): void {
+    localStorage.removeItem(key);
   }
 }
 
@@ -25,6 +31,10 @@ class NodeStorage implements IStorage {
 
   public setItem(key: string, value: string): void {
     this.storage[key] = value;
+  }
+
+  public removeItem(key: string) {
+    delete this.storage[key];
   }
 }
 
@@ -49,5 +59,9 @@ export class LocalStorage {
   public setAuthSignature(key: string, authSignature: AuthSignature): void {
     const asJson = JSON.stringify(authSignature);
     this.storage.setItem(key, asJson);
+  }
+
+  public clear(key: string): void {
+    this.storage.removeItem(key);
   }
 }

--- a/packages/taco-auth/test/auth-provider.test.ts
+++ b/packages/taco-auth/test/auth-provider.test.ts
@@ -5,7 +5,7 @@ import {
   TEST_SIWE_PARAMS,
 } from '@nucypher/test-utils';
 import { SiweMessage } from 'siwe';
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { EIP4361AuthProvider } from '../src/providers';
 import { EIP4361TypedDataSchema } from '../src/providers/eip4361/common';
@@ -50,5 +50,52 @@ describe('auth provider', () => {
     expect(() =>
       EIP4361TypedDataSchema.parse(typedSignature.typedData),
     ).toThrow();
+  });
+});
+
+describe('auth provider caching', () => {
+  beforeEach(() => {
+    // tell vitest we use mocked time
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    // restoring date after each test run
+    vi.useRealTimers();
+  });
+
+  const provider = fakeProvider(bobSecretKeyBytes);
+  const signer = fakeSigner(bobSecretKeyBytes);
+  const eip4361Provider = new EIP4361AuthProvider(
+    provider,
+    signer,
+    TEST_SIWE_PARAMS,
+  );
+
+  it('caches auth signature, but regenerates when expired', async () => {
+    const createAuthSignatureSpy = vi.spyOn(
+      eip4361Provider,
+      'createSIWEAuthMessage',
+    );
+
+    const typedSignature = await eip4361Provider.getOrCreateAuthSignature();
+    expect(createAuthSignatureSpy).toHaveBeenCalledTimes(1);
+
+    const typedSignatureSecondCall =
+      await eip4361Provider.getOrCreateAuthSignature();
+    // auth signature not expired, so spy is not called a 2nd time
+    expect(createAuthSignatureSpy).toHaveBeenCalledTimes(1);
+    expect(typedSignatureSecondCall).toEqual(typedSignature);
+
+    // time travel to 2h:1m in the future; auth signature is now expired
+    const now = new Date();
+    now.setHours(now.getHours() + 2, now.getMinutes() + 1);
+    vi.setSystemTime(now);
+
+    const typedSignatureThirdCall =
+      await eip4361Provider.getOrCreateAuthSignature();
+    // auth signature is now expired, so spy is called a 2nd time
+    expect(createAuthSignatureSpy).toHaveBeenCalledTimes(2);
+    expect(typedSignatureThirdCall).not.toEqual(typedSignature);
   });
 });

--- a/packages/taco/src/index.ts
+++ b/packages/taco/src/index.ts
@@ -10,8 +10,8 @@ export {
 } from '@nucypher/shared';
 
 export * as conditions from './conditions';
-// TODO(#324): Expose registerEncrypters from taco API
-export { decrypt, encrypt, encryptWithPublicKey, isAuthorized } from './taco';
+
+export { decrypt, encrypt, encryptWithPublicKey } from './taco';
 
 // TODO: Remove this re-export once `@nucypher/taco-auth` is mature and published
 export {

--- a/packages/taco/src/taco.ts
+++ b/packages/taco/src/taco.ts
@@ -5,12 +5,10 @@ import {
   ThresholdMessageKit,
 } from '@nucypher/nucypher-core';
 import {
-  ChecksumAddress,
   DkgCoordinatorAgent,
   Domain,
   fromHexString,
   getPorterUris,
-  GlobalAllowListAgent,
   PorterClient,
   toBytes,
 } from '@nucypher/shared';
@@ -158,48 +156,5 @@ export const decrypt = async (
     messageKit,
     ritualId,
     context,
-  );
-};
-
-/**
- * Checks if the encryption from the provided messageKit is authorized for the specified ritual.
- *
- * @export
- * @param {ethers.providers.Provider} provider - Instance of ethers provider which is used to interact with
- * your selected network.
- * @param {Domain} domain - The domain which was used to encrypt the network. Must match the `ritualId`.
- * @param {ThresholdMessageKit} messageKit - The encrypted message kit to be checked.
- * @param {number} ritualId - The ID of the DKG Ritual under which the messageKit was supposedly encrypted.
- *
- * @returns {Promise<boolean>} Returns a Promise that resolves with the authorization status.
- * True if authorized, false otherwise
- */
-export const isAuthorized = async (
-  provider: ethers.providers.Provider,
-  domain: Domain,
-  messageKit: ThresholdMessageKit,
-  ritualId: number,
-): Promise<boolean> =>
-  DkgCoordinatorAgent.isEncryptionAuthorized(
-    provider,
-    domain,
-    ritualId,
-    messageKit,
-  );
-
-// TODO is this still valid and actually needed? should we remove this?
-export const registerEncrypters = async (
-  provider: ethers.providers.Provider,
-  signer: ethers.Signer,
-  domain: Domain,
-  ritualId: number,
-  encrypters: ChecksumAddress[],
-): Promise<void> => {
-  await GlobalAllowListAgent.registerEncrypters(
-    provider,
-    signer,
-    domain,
-    ritualId,
-    encrypters,
   );
 };

--- a/packages/taco/test/conditions/context.test.ts
+++ b/packages/taco/test/conditions/context.test.ts
@@ -7,11 +7,7 @@ import {
   USER_ADDRESS_PARAM_DEFAULT,
   USER_ADDRESS_PARAM_EXTERNAL_EIP4361,
 } from '@nucypher/taco-auth';
-import {
-  fakeAuthProviders,
-  fakeProvider,
-  fakeSigner,
-} from '@nucypher/test-utils';
+import { fakeAuthProviders, fakeProvider } from '@nucypher/test-utils';
 import { ethers } from 'ethers';
 import { beforeAll, describe, expect, it, vi } from 'vitest';
 
@@ -308,8 +304,8 @@ describe('context', () => {
 
 // TODO: Move to a separate file
 describe('No authentication provider', () => {
-  let provider: ethers.providers.Provider;
-  let signer: ethers.Signer;
+  let provider: ethers.providers.Web3Provider;
+  let signer: ethers.providers.JsonRpcSigner;
   let authProviders: Record<string, AuthProvider>;
 
   async function testEIP4361AuthSignature(
@@ -337,8 +333,8 @@ describe('No authentication provider', () => {
   beforeAll(async () => {
     await initialize();
     provider = fakeProvider();
-    signer = fakeSigner();
-    authProviders = await fakeAuthProviders();
+    signer = provider.getSigner();
+    authProviders = await fakeAuthProviders(signer);
   });
 
   it('throws an error if there is no auth provider', () => {

--- a/packages/taco/test/taco.test.ts
+++ b/packages/taco/test/taco.test.ts
@@ -10,7 +10,6 @@ import {
   fakeDkgFlow,
   fakePorterUri,
   fakeProvider,
-  fakeSigner,
   fakeTDecFlow,
   mockGetRitualIdFromPublicKey,
   mockTacoDecrypt,
@@ -48,7 +47,7 @@ describe('taco', () => {
     const mockedDkg = fakeDkgFlow(FerveoVariant.precomputed, 0, 4, 4);
     const mockedDkgRitual = fakeDkgRitual(mockedDkg);
     const provider = fakeProvider(aliceSecretKeyBytes);
-    const signer = fakeSigner(aliceSecretKeyBytes);
+    const signer = provider.getSigner();
     const getFinalizedRitualSpy = mockGetActiveRitual(mockedDkgRitual);
 
     const messageKit = await taco.encrypt(
@@ -110,7 +109,7 @@ describe('taco', () => {
     const mockedDkg = fakeDkgFlow(FerveoVariant.precomputed, 0, 4, 4);
     const mockedDkgRitual = fakeDkgRitual(mockedDkg);
     const provider = fakeProvider(aliceSecretKeyBytes);
-    const signer = fakeSigner(aliceSecretKeyBytes);
+    const signer = provider.getSigner();
     const getFinalizedRitualSpy = mockGetActiveRitual(mockedDkgRitual);
 
     const customParamKey = ':nftId';

--- a/packages/taco/test/test-utils.ts
+++ b/packages/taco/test/test-utils.ts
@@ -27,7 +27,7 @@ import {
 } from '@nucypher/shared';
 import {
   fakeDkgFlow,
-  fakeSigner,
+  fakeProvider,
   fakeTDecFlow,
   TEST_CHAIN_ID,
   TEST_CONTRACT_ADDR,
@@ -84,11 +84,12 @@ export const fakeDkgTDecFlowE2E: (
 ) => {
   const ritual = fakeDkgFlow(variant, ritualId, sharesNum, threshold);
   const dkgPublicKey = ritual.dkg.publicKey();
+  const provider = fakeProvider();
   const thresholdMessageKit = await encryptMessage(
     message,
     dkgPublicKey,
     conditionExpr,
-    fakeSigner(),
+    provider.getSigner(),
   );
 
   const { decryptionShares } = fakeTDecFlow({

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -18,7 +18,12 @@ export default defineConfig({
       reporter: ['text', 'html', 'lcov', 'clover'],
       reportsDirectory: 'coverage',
       include: ['packages/**/*.ts'],
-      exclude: ['packages/**/*.test.ts'],
+      exclude: [
+        'packages/**/*.test.ts',
+        'packages/taco/examples/*.ts',
+        'packages/shared/scripts/*.ts',
+        'packages/test-utils/**/*.ts',
+      ],
     },
   },
 });


### PR DESCRIPTION
**Type of PR:**

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [x] Other

**Required reviews:**

- [ ] 1
- [ ] 2
- [x] 3

**What this does:**

> High-level idea of the changes introduced in this PR. List relevant API
> changes (if any), as well as related PRs and issues.

Based over #560 (somewhat of a follow-up PR).

- `EIP4361AuthProvider` caches the auth signature it first generates perpetually (unless storage is explicitly cleared eg. `localStorage.clear()` in apps). However, this auth signature can become expired (> 2h old), and so the provider should detect that on cache retrieval and regenerate the auth signature if it becomes expired.
- Add test for `SingleSignOnEIP4361AuthProvider`
- Clean up tests so that signer is obtained from provider, instead of creating separate `fakeProvider()` and `fakeSigner()`; this way they are better linked for tests. This only applies to tests - in real life it is possible to have a signer with no provider, but this was not the case for tests prior to this change anyway.
- Remove no longer applicable/superfluous API calls from being exposed:
   - `isAuthorized(...)` - calls into the `Coordinator` contract to call this function, but we are moving away from this where calls should be made directly to the `AccessController`. However the accessController only checks for `isEncryptionAuthorized` and doesn't provide the ability to check if an encrypted address is authorized - which is what is implemented here. Therefore, it only applies to the GlobalAllowList contracts, but it's unclear if we need that ability in `taco-web`
   - `registerEncrypters(...)` - Was never publicly exposed and it is unclear if we need this ability in `taco-web`. #324 alluded to it, but not sure if we still care. Let me know if we do (cc @arjunhassard ).
   
   *If we decide down the road we need them, we can add them back.*

**Issues fixed/closed:**

> - Fixes #...

Closes https://github.com/nucypher/taco-web/issues/324

**Why it's needed:**

> Explain how this PR fits in the greater context of the NuCypher Network. E.g.,
> if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**

> What should reviewers focus on? Is there a particular commit/function/section
> of your PR that requires more attention from reviewers?
