### PR TITLE
Update Ritual ID on test lynx workflow

### DIFF
--- a/.github/workflows/lynx.yml
+++ b/.github/workflows/lynx.yml
@@ -11,7 +11,7 @@ env:
   RPC_PROVIDER_URL: 'https://rpc-amoy.polygon.technology'
   ENCRYPTOR_PRIVATE_KEY: '0x900edb9e8214b2353f82aa195e915128f419a92cfb8bbc0f4784f10ef4112b86'
   CONSUMER_PRIVATE_KEY: '0xf307e165339cb5deb2b8ec59c31a5c0a957b8e8453ce7fe8a19d9a4c8acf36d4'
-  RITUAL_ID: '0'
+  RITUAL_ID: '27'
 
 jobs:
   networks:


### PR DESCRIPTION
**Type of PR:**

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:**

- [x] 1
- [ ] 2
- [ ] 3

**What this does:**

This change will change the ritual ID used by the test performed every hour on the Lynx network. This is needed because the Lynx ritual `#0` has expired, so a new ritual has been initiated (`#27`).

**Notes for reviewers:**

This PR has been opened through a branch on the repo (`update-ritual-id`) instead of a branch on my fork since I needed to test the change before opening this PR.
