### PR TITLE
docs: include `taco-auth` in api docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,8 +24,8 @@ pnpm fix
 Build and publish documentation with:
 
 ```bash
-pnpm doc
-pnpm doc:publish
+pnpm typedoc
+pnpm typedoc:publish
 ```
 
 ## Publishing

--- a/packages/taco-auth/test/auth-provider.test.ts
+++ b/packages/taco-auth/test/auth-provider.test.ts
@@ -77,6 +77,7 @@ describe('auth provider caching', () => {
   it('caches auth signature, but regenerates when expired', async () => {
     const createAuthSignatureSpy = vi.spyOn(
       eip4361Provider,
+      // @ts-expect-error -- spying on private function
       'createSIWEAuthMessage',
     );
 

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,6 +1,6 @@
 {
   "extends": ["./typedoc.base.json"],
-  "entryPoints": ["packages/pre", "packages/shared", "packages/taco", "packages/taco-auth"],
+  "entryPoints": ["packages/shared", "packages/taco", "packages/taco-auth"],
   "entryPointStrategy": "packages",
   "name": "@nucypher/taco-web"
 }

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,6 +1,6 @@
 {
   "extends": ["./typedoc.base.json"],
-  "entryPoints": ["packages/pre", "packages/shared", "packages/taco"],
+  "entryPoints": ["packages/pre", "packages/shared", "packages/taco", "packages/taco-auth"],
   "entryPointStrategy": "packages",
   "name": "@nucypher/taco-web"
 }


### PR DESCRIPTION
**Type of PR:**

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [x] Other

**Required reviews:**

- [x] 1
- [ ] 2
- [ ] 3

**What this does:**

Noticed while working on TACo docs that `taco-auth` is not included in published docs for `taco-web`.

Docs are now updated. See https://nucypher.github.io/taco-web/.

**Issues fixed/closed:**

> - Fixes #...

**Why it's needed:**

> Explain how this PR fits in the greater context of the NuCypher Network. E.g.,
> if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**

> What should reviewers focus on? Is there a particular commit/function/section
> of your PR that requires more attention from reviewers?
