### PR TITLE
chore: update ritual used by Tapir action

### DIFF
--- a/.github/workflows/tapir.yml
+++ b/.github/workflows/tapir.yml
@@ -13,7 +13,7 @@ env:
   RPC_PROVIDER_URL: 'https://rpc-amoy.polygon.technology'
   ENCRYPTOR_PRIVATE_KEY: '0x900edb9e8214b2353f82aa195e915128f419a92cfb8bbc0f4784f10ef4112b86'
   CONSUMER_PRIVATE_KEY: '0xf307e165339cb5deb2b8ec59c31a5c0a957b8e8453ce7fe8a19d9a4c8acf36d4'
-  RITUAL_ID: '0'
+  RITUAL_ID: '6'
 
 jobs:
   networks:

--- a/demos/taco-demo/src/config.ts
+++ b/demos/taco-demo/src/config.ts
@@ -1,6 +1,6 @@
 import { domains } from '@nucypher/taco';
 
-export const DEFAULT_RITUAL_ID = parseInt(process.env.DEFAULT_RITUAL_ID || '0');
+export const DEFAULT_RITUAL_ID = parseInt(process.env.DEFAULT_RITUAL_ID || '6');
 export const DEFAULT_DOMAIN = process.env.DEFAULT_DOMAIN || domains.TESTNET;
 
 // Node 2 is free

--- a/demos/taco-nft-demo/src/config.ts
+++ b/demos/taco-nft-demo/src/config.ts
@@ -1,4 +1,4 @@
 import { domains } from '@nucypher/taco';
 
-export const DEFAULT_RITUAL_ID = parseInt(process.env.DEFAULT_RITUAL_ID || '0');
+export const DEFAULT_RITUAL_ID = parseInt(process.env.DEFAULT_RITUAL_ID || '6');
 export const DEFAULT_DOMAIN = process.env.DEFAULT_DOMAIN || domains.TESTNET;

--- a/examples/taco/nextjs/src/app/page.tsx
+++ b/examples/taco/nextjs/src/app/page.tsx
@@ -10,7 +10,7 @@ import useTaco from '../hooks/useTaco';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 declare const window: any;
 
-const ritualId = 0; // Replace with your own ritual ID
+const ritualId = 6; // Replace with your own ritual ID
 const domain = domains.TESTNET;
 
 function App() {

--- a/examples/taco/nodejs/.env.example
+++ b/examples/taco/nodejs/.env.example
@@ -5,5 +5,5 @@ RPC_PROVIDER_URL=https://rpc-amoy.polygon.technology
 # We provide here some defaults, but we encourage you to choose your own.
 ENCRYPTOR_PRIVATE_KEY=0x900edb9e8214b2353f82aa195e915128f419a92cfb8bbc0f4784f10ef4112b86
 CONSUMER_PRIVATE_KEY=0xf307e165339cb5deb2b8ec59c31a5c0a957b8e8453ce7fe8a19d9a4c8acf36d4
-RITUAL_ID=0
+RITUAL_ID=6
 DOMAIN=tapir

--- a/examples/taco/nodejs/src/index.ts
+++ b/examples/taco/nodejs/src/index.ts
@@ -36,7 +36,7 @@ if (!consumerPrivateKey) {
 }
 
 const domain = process.env.DOMAIN || domains.TESTNET;
-const ritualId = parseInt(process.env.RITUAL_ID || '0');
+const ritualId = parseInt(process.env.RITUAL_ID || '6');
 const provider = new ethers.providers.JsonRpcProvider(rpcProviderUrl);
 const CHAIN_ID_FOR_DOMAIN = {
   [domains.MAINNET]: 137,

--- a/examples/taco/react/src/App.tsx
+++ b/examples/taco/react/src/App.tsx
@@ -9,7 +9,7 @@ import useTaco from './hooks/useTaco';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 declare const window: any;
 
-const ritualId = 0; // Replace with your own ritual ID
+const ritualId = 6; // Replace with your own ritual ID
 const domain = domains.TESTNET;
 
 function App() {

--- a/examples/taco/webpack-5/src/index.ts
+++ b/examples/taco/webpack-5/src/index.ts
@@ -20,7 +20,7 @@ declare const window: any;
 const runExample = async () => {
   await initialize();
 
-  const ritualId = 0; // Replace with your own ritual ID
+  const ritualId = 6; // Replace with your own ritual ID
   const domain = domains.TESTNET;
 
   const provider = new ethers.providers.Web3Provider(window.ethereum!, 'any');


### PR DESCRIPTION
**Type of PR:**

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:**

- [ ] 1
- [x] 2
- [ ] 3

**What this does:**

The open ritual that we used for developers has expired on Oct 6th 24, so a new ritual `#6` has been created for this.

**Notes for reviewers:**

Failing tests should pass when this change is merged.

epic-v0.6.x branch should rebase this change once merged.
