### PR TITLE
Update ritual ID used in mainnet checks

### DIFF
--- a/.github/workflows/mainnet.yml
+++ b/.github/workflows/mainnet.yml
@@ -10,7 +10,7 @@ env:
   RPC_PROVIDER_URL: 'https://polygon.llamarpc.com'
   ENCRYPTOR_PRIVATE_KEY: ${{ secrets.MAINNET_ENCRYPTOR_PRIVATE_KEY }}
   CONSUMER_PRIVATE_KEY: ${{ secrets.MAINNET_CONSUMER_PRIVATE_KEY }}
-  RITUAL_ID: '9'
+  RITUAL_ID: '39'
 
 jobs:
   networks:


### PR DESCRIPTION
The previous ritual has expired, so a new ritual has been generated to check that mainnet TACo domain is up and running.

**Type of PR:**
- [X] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:**
- [X] 2

**Notes for reviewers:**
The PR was created over a branch on this repo instead of my fork because AFAIK having a branch here is the easiest way to trigger the CI tests.
