### PR TITLE
Use default hardcoded values for `domain` and `uri` within the EIP4361 message in non-browser environment

### DIFF
--- a/packages/taco-auth/src/providers/eip4361/eip4361.ts
+++ b/packages/taco-auth/src/providers/eip4361/eip4361.ts
@@ -13,7 +13,8 @@ export type EIP4361AuthProviderParams = {
   uri: string;
 };
 
-const ERR_MISSING_SIWE_PARAMETERS = 'Missing default SIWE parameters';
+const TACO_DEFAULT_DOMAIN = 'taco.build';
+const TACO_DEFAULT_URI = 'https://taco.build';
 
 export class EIP4361AuthProvider {
   private readonly storage: LocalStorage;
@@ -41,8 +42,12 @@ export class EIP4361AuthProvider {
         uri: window.location?.origin,
       };
     }
-    // If not, we have no choice but to throw an error
-    throw new Error(ERR_MISSING_SIWE_PARAMETERS);
+
+    // not in a browser environment, use hardcoded defaults
+    return {
+      domain: TACO_DEFAULT_DOMAIN,
+      uri: TACO_DEFAULT_URI,
+    };
   }
 
   public async getOrCreateAuthSignature(): Promise<AuthSignature> {

--- a/packages/taco-auth/test/auth-provider.test.ts
+++ b/packages/taco-auth/test/auth-provider.test.ts
@@ -21,6 +21,28 @@ describe('auth provider', () => {
     TEST_SIWE_PARAMS,
   );
 
+  it('creates new SIWE message with default parameters', async () => {
+    const defaultEip4361Provider = new EIP4361AuthProvider(provider, signer);
+
+    const typedSignature =
+      await defaultEip4361Provider.getOrCreateAuthSignature();
+    expect(typedSignature.signature).toBeDefined();
+    expect(typedSignature.address).toEqual(await signer.getAddress());
+    expect(typedSignature.scheme).toEqual('EIP4361');
+    const typedDataSiweMessage = new SiweMessage(`${typedSignature.typedData}`);
+    expect(typedDataSiweMessage).toBeDefined();
+    expect(typedDataSiweMessage.domain).toEqual('taco.build');
+    expect(typedDataSiweMessage.version).toEqual('1');
+    expect(typedDataSiweMessage.nonce).toBeDefined(); // random
+    expect(typedDataSiweMessage.uri).toEqual('https://taco.build');
+    expect(typedDataSiweMessage.chainId).toEqual(
+      (await provider.getNetwork()).chainId,
+    );
+    expect(typedDataSiweMessage.statement).toEqual(
+      `${typedDataSiweMessage.domain} wants you to sign in with your Ethereum account: ${await signer.getAddress()}`,
+    );
+  });
+
   it('creates a new SIWE message', async () => {
     const typedSignature = await eip4361Provider.getOrCreateAuthSignature();
     expect(typedSignature.signature).toBeDefined();


### PR DESCRIPTION
**Type of PR:**

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:**

- [ ] 1
- [x] 2
- [ ] 3

**What this does:**
There isn't anything from a programmatic/non-browser based scenario that prevents us from using default hardcoded values if:
1) specific values aren't provided by application
AND
2) we are not in a browser-based environment.

Therefore, you could do something like, if the above scenarios hold then we use `https://taco.build` and `taco.build` as the defaults (of course we can use something else) for uri and domain respectively. 

In a programmatic environment, it shouldn't really care the domain/URI value, just that the wallet signed something. Even more broadly, the `domain` and `uri` values are really for UI elements to show the user that the connected site is indeed prompting for SIWE. Furthermore, TACo nodes don't verify anything with domain and uri, they only verify signature and expiry. At the end of the day, it's still just a signed structured message (EIP4361 or EIP712). EIP712 would also include other default values to it anyway, so it feels like adding EIP712 just for this purpose would be superfluous, and EIP4361 could suffice.

**Issues fixed/closed:**
- Related to https://github.com/nucypher/sprints/issues/116#issuecomment-2610878836

**Why it's needed:**

> Explain how this PR fits in the greater context of the NuCypher Network. E.g.,
> if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**

> What should reviewers focus on? Is there a particular commit/function/section
> of your PR that requires more attention from reviewers?
