### PR TITLE
fix: update vitest configuration to properly load environment variables

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,15 @@
+# URL for RPC blockchain provider. For TACo testnet you should use a Polygon Amoy endpoint.
+# Current default extracted from https://chainlist.org/chain/80002, but ideally, you'll use your own endpoint.
+RPC_PROVIDER_URL=https://rpc-amoy.polygon.technology
+# Hex-encoded private keys for the Encryptor and the Consumer.
+# You can generate a new key pair using ethers.js and set them locally or in the CI:
+# $ node -e "console.log('🔑 Private Key:', require('crypto').randomBytes(32).toString('hex'))"
+# ENCRYPTOR_PRIVATE_KEY=0x900edb9e8214b2353f82aa195e915128f419a92cfb8bbc0f4784f10ef4112b86
+# CONSUMER_PRIVATE_KEY=0xf307e165339cb5deb2b8ec59c31a5c0a957b8e8453ce7fe8a19d9a4c8acf36d4
+
+DOMAIN=lynx
+RITUAL_ID=27
+CHAIN_ID=80002
+
+# When running in CI, set this to true to run integration tests
+RUN_INTEGRATION_TEST=true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Test
         env:
-          RUNNING_IN_CI: true
+          RUN_INTEGRATION_TEST: true
         run: pnpm test
 
       - name: Check examples & demos

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "build": "tsc --build --verbose ./tsconfig.prod.json",
     "watch": "tsc --build --verbose --watch ./tsconfig.prod.json",
     "test": "pnpm build && vitest run",
+    "test:integration": "pnpm --filter @nucypher/taco test:integration",
     "package:check": "pnpm run --parallel --aggregate-output --reporter append-only --filter './packages/**' package-check",
     "packages:lint": "pnpm packages:sort --check",
     "packages:sort": "sort-package-json \"package.json\" \"examples/*/package.json\" \"packages/*/package.json\"",

--- a/packages/taco/integration-test/encrypt-decrypt.test.ts
+++ b/packages/taco/integration-test/encrypt-decrypt.test.ts
@@ -16,16 +16,20 @@ import {
 import { CompoundCondition } from '../src/conditions/compound-condition';
 import { UINT256_MAX } from '../test/test-utils';
 
-const RPC_PROVIDER_URL = 'https://rpc-amoy.polygon.technology';
+const RPC_PROVIDER_URL = process.env.RPC_PROVIDER_URL as string;
 const ENCRYPTOR_PRIVATE_KEY =
-  '0x900edb9e8214b2353f82aa195e915128f419a92cfb8bbc0f4784f10ef4112b86';
+  (process.env.ENCRYPTOR_PRIVATE_KEY as string) ||
+  require('crypto').randomBytes(32).toString('hex');
 const CONSUMER_PRIVATE_KEY =
-  '0xf307e165339cb5deb2b8ec59c31a5c0a957b8e8453ce7fe8a19d9a4c8acf36d4';
-const DOMAIN = 'lynx';
-const RITUAL_ID = 27;
-const CHAIN_ID = 80002;
+  (process.env.CONSUMER_PRIVATE_KEY as string) ||
+  require('crypto').randomBytes(32).toString('hex');
+const DOMAIN = process.env.DOMAIN as string;
+const RITUAL_ID = Number(process.env.RITUAL_ID);
+const CHAIN_ID = Number(process.env.CHAIN_ID);
 
-describe.skipIf(!process.env.RUNNING_IN_CI)(
+const RUN_INTEGRATION_TEST = Boolean(process.env.RUN_INTEGRATION_TEST);
+
+describe.skipIf(!RUN_INTEGRATION_TEST)(
   'Taco Encrypt/Decrypt Integration Test',
   () => {
     let provider: ethers.providers.JsonRpcProvider;

--- a/packages/taco/integration-test/vitest.config.ts
+++ b/packages/taco/integration-test/vitest.config.ts
@@ -1,7 +1,10 @@
+import { loadEnv } from 'vite';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
+    // use env at the mono repo root
+    env: loadEnv('test', process.cwd() + '/../../', ''),
     root: __dirname,
     watch: false,
     pool: 'forks',

--- a/packages/taco/package.json
+++ b/packages/taco/package.json
@@ -32,7 +32,7 @@
     "clean": "rm -rf dist",
     "exports:lint": "ts-unused-exports tsconfig.json --ignoreFiles src/index.ts",
     "generate-zod-docs": "pnpm dlx tsx scripts/schema-docs-generation.ts",
-    "integration-test": "vitest run --config integration-test/vitest.config.ts",
+    "test:integration": "vitest run --config integration-test/vitest.config.ts",
     "lint": "eslint --ext .ts src test",
     "lint:fix": "pnpm lint --fix",
     "package-check": "package-check",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,7 +1,9 @@
+import { loadEnv } from 'vite';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
+    env: loadEnv('test', process.cwd(), ''),
     root: __dirname,
     watch: false,
     pool: 'forks',


### PR DESCRIPTION
**Type of PR:**

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [x] Other (Testing)

**Required reviews:**

- [ ] 1
- [ ] 2
- [x] 3

**What this does:**

This change resolves an issue where vitest test runner was unable to read 
environment variables during test execution, affecting
integration test. Ensures dotenv is properly integrated with the vitest 
configuration.
And add a script to the root folder named test:integration to just run the integration test (useful especially when testing locally).

**Issues fixed/closed:**
This could close https://github.com/nucypher/taco-web/issues/638 or could be just a fast fix related to it.


**Why it's needed:**

> Explain how this PR fits in the greater context of the NuCypher Network. E.g.,
> if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**

> What should reviewers focus on? Is there a particular commit/function/section
> of your PR that requires more attention from reviewers?
