### PR TITLE
Add integration test for condition lingo validation

### DIFF
--- a/packages/taco/integration-test/condition-lingo.test.ts
+++ b/packages/taco/integration-test/condition-lingo.test.ts
@@ -48,6 +48,7 @@ async function validateConditionExpression(
   return;
 }
 
+// skip integration test if RUNNING_IN_CI is not set (it is set in CI environments)
 describe.skipIf(!process.env.RUNNING_IN_CI)(
   'TACo Condition Lingos Integration Test',
   () => {

--- a/packages/taco/integration-test/condition-lingo.test.ts
+++ b/packages/taco/integration-test/condition-lingo.test.ts
@@ -1,0 +1,103 @@
+import axios from 'axios';
+import * as https from 'https';
+import { describe, test } from 'vitest';
+import { CompoundConditionType } from '../src/conditions/compound-condition';
+import { ConditionExpression } from '../src/conditions/condition-expr';
+import { IfThenElseConditionType } from '../src/conditions/if-then-else-condition';
+import { SequentialCondition } from '../src/conditions/sequential';
+import {
+  testContractConditionObj,
+  testJsonApiConditionObj,
+  testJsonRpcConditionObj,
+  testJWTConditionObj,
+  testRpcConditionObj,
+  testSigningObjectAbiAttributeConditionObj,
+  testSigningObjectAttributeConditionObj,
+  testTimeConditionObj,
+} from '../test/test-utils';
+
+const LYNX_NODES = [
+  'https://lynx-1.nucypher.network',
+  'https://lynx-2.nucypher.network',
+  'https://lynx-3.nucypher.network',
+];
+
+async function validateConditionExpression(
+  conditionExpr: ConditionExpression,
+): Promise<void> {
+  const lynxNode = LYNX_NODES[Math.floor(Math.random() * LYNX_NODES.length)];
+  const httpsAgent = new https.Agent({
+    rejectUnauthorized: false,
+  });
+
+  const response = await axios.post(
+    `${lynxNode}:9151/validate_condition_lingo`,
+    JSON.stringify(conditionExpr.toJson()),
+    {
+      httpsAgent,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    },
+  );
+  if (response.status !== 200) {
+    throw new Error(
+      `Request failed with status ${response.status}: ${JSON.stringify(response.data)}`,
+    );
+  }
+  return;
+}
+
+describe.skipIf(!process.env.RUNNING_IN_CI)(
+  'TACo Condition Lingos Integration Test',
+  () => {
+    test('validate condition lingo with lynx node to confirm consistency', async () => {
+      const overallCondition = new SequentialCondition({
+        conditionVariables: [
+          {
+            varName: 'rpc',
+            condition: testRpcConditionObj,
+          },
+          {
+            varName: 'time',
+            condition: testTimeConditionObj,
+          },
+          {
+            varName: 'contract',
+            condition: testContractConditionObj,
+          },
+          {
+            varName: 'compound',
+            condition: {
+              conditionType: CompoundConditionType,
+              operator: 'or',
+              operands: [
+                testJsonApiConditionObj,
+                testJsonRpcConditionObj,
+                testSigningObjectAbiAttributeConditionObj,
+                testSigningObjectAttributeConditionObj,
+              ],
+            },
+          },
+          {
+            varName: 'ifThenElse',
+            condition: {
+              conditionType: IfThenElseConditionType,
+              ifCondition: testJWTConditionObj,
+              thenCondition: {
+                ...testJsonApiConditionObj,
+                authorizationToken: ':authToken',
+              },
+              elseCondition: {
+                ...testJsonRpcConditionObj,
+                authorizationToken: ':otherAuthToken',
+              },
+            },
+          },
+        ],
+      });
+      const conditionExpr = new ConditionExpression(overallCondition);
+      await validateConditionExpression(conditionExpr);
+    }, 15000);
+  },
+);

--- a/packages/taco/integration-test/encrypt-decrypt.test.ts
+++ b/packages/taco/integration-test/encrypt-decrypt.test.ts
@@ -25,6 +25,7 @@ const DOMAIN = 'lynx';
 const RITUAL_ID = 27;
 const CHAIN_ID = 80002;
 
+// skip integration test if RUNNING_IN_CI is not set (it is set in CI environments)
 describe.skipIf(!process.env.RUNNING_IN_CI)(
   'TACo Encrypt/Decrypt Integration Test',
   () => {

--- a/packages/taco/integration-test/encrypt-decrypt.test.ts
+++ b/packages/taco/integration-test/encrypt-decrypt.test.ts
@@ -26,7 +26,7 @@ const RITUAL_ID = 27;
 const CHAIN_ID = 80002;
 
 describe.skipIf(!process.env.RUNNING_IN_CI)(
-  'Taco Encrypt/Decrypt Integration Test',
+  'TACo Encrypt/Decrypt Integration Test',
   () => {
     let provider: ethers.providers.JsonRpcProvider;
     let encryptorSigner: ethers.Wallet;

--- a/packages/taco/integration-test/sign.test.ts
+++ b/packages/taco/integration-test/sign.test.ts
@@ -13,7 +13,7 @@ const RITUAL_ID = 1;
 const CHAIN_ID = 11155111;
 
 describe.skipIf(!process.env.RUNNING_IN_CI)(
-  'Taco Sign Integration Test',
+  'TACo Sign Integration Test',
   () => {
     let provider: ethers.providers.JsonRpcProvider;
 
@@ -82,6 +82,6 @@ describe.skipIf(!process.env.RUNNING_IN_CI)(
       expect(signResult.aggregatedSignature).toBeDefined();
       expect(signResult.signingResults).toBeDefined();
       expect(Object.keys(signResult.signingResults).length).toBeGreaterThan(0);
-    }, 150000);
+    }, 15000);
   },
 );

--- a/packages/taco/integration-test/sign.test.ts
+++ b/packages/taco/integration-test/sign.test.ts
@@ -12,6 +12,7 @@ const DOMAIN = 'lynx';
 const RITUAL_ID = 1;
 const CHAIN_ID = 11155111;
 
+// skip integration test if RUNNING_IN_CI is not set (it is set in CI environments)
 describe.skipIf(!process.env.RUNNING_IN_CI)(
   'TACo Sign Integration Test',
   () => {

--- a/packages/taco/package.json
+++ b/packages/taco/package.json
@@ -52,6 +52,7 @@
   "devDependencies": {
     "@nucypher/test-utils": "workspace:*",
     "@types/semver": "^7.7.0",
+    "axios": "^1.8.4",
     "dotenv": "^16.4.7",
     "glob": "^11.0.1",
     "modified-zod2md": "0.1.5-modified.4"

--- a/packages/taco/test/conditions/condition-expr.test.ts
+++ b/packages/taco/test/conditions/condition-expr.test.ts
@@ -414,9 +414,7 @@ describe('condition set', () => {
       const conditionExprJson = conditionExpr.toJson();
       expect(conditionExprJson).toBeDefined();
       expect(conditionExprJson).toContain('endpoint');
-      expect(conditionExprJson).toContain(
-        'https://_this_would_totally_fail.com',
-      );
+      expect(conditionExprJson).toContain('https://api.example.com/data');
       expect(conditionExprJson).toContain('parameters');
       expect(conditionExprJson).toContain('query');
       expect(conditionExprJson).toContain('$.ethereum.usd');

--- a/packages/taco/test/test-utils.ts
+++ b/packages/taco/test/test-utils.ts
@@ -265,7 +265,7 @@ export const testTimeConditionObj: TimeConditionProps = {
 
 export const testJsonApiConditionObj: JsonApiConditionProps = {
   conditionType: JsonApiConditionType,
-  endpoint: 'https://_this_would_totally_fail.com',
+  endpoint: 'https://api.example.com/data',
   parameters: {
     ids: 'ethereum',
     vs_currencies: 'usd',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -589,6 +589,9 @@ importers:
       '@types/semver':
         specifier: ^7.7.0
         version: 7.7.0
+      axios:
+        specifier: ^1.8.4
+        version: 1.10.0
       dotenv:
         specifier: ^16.4.7
         version: 16.5.0


### PR DESCRIPTION
**Type of PR:**

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [x] Other

**Required reviews:**

- [ ] 1
- [x] 2
- [ ] 3

**What this does:**
This integration test ensures that conditions created in `taco-web` properly match the condition structure expected by nodes i.e. that the `zod` schema implemented in typescript matches the `marshmallow` schema implemented in python. 

Until now, we've been able to do that test by attaching conditions to encrypted data, then asking the node to decrypt the data. But when nodes sign data, the conditions are obtained from the SigningCoordinator contract and not from the signing request, so we can't just test signing with different conditions easily.

To test the condition lingo can be sent to the `/validate_condition_lingo` endpoint of any `lynx` node; related to https://github.com/nucypher/nucypher/pull/3615.

The integration test collects the various condition types into one condition for efficiency since the round trip of the test can take a couple seconds. As we add addition condition types we should expand the condition used for the lingo test.

**Issues fixed/closed:**

> - Fixes #...

**Why it's needed:**

> Explain how this PR fits in the greater context of the NuCypher Network. E.g.,
> if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**

> What should reviewers focus on? Is there a particular commit/function/section
> of your PR that requires more attention from reviewers?
