### PR TITLE
Allow JSON API/RPC conditions to optionally specify `authorizationType`

### DIFF
--- a/packages/taco/integration-test/condition-lingo.test.ts
+++ b/packages/taco/integration-test/condition-lingo.test.ts
@@ -53,30 +53,51 @@ describe.skipIf(!process.env.RUNNING_IN_CI)(
   'TACo Condition Lingos Integration Test',
   () => {
     test('validate condition lingo with lynx node to confirm consistency', async () => {
+      // Note: there are limits to conditions
+      // - max 5 operands in a multi-condition (compound, sequential)
+      // - max 2 nested levels of multi-conditions (compound, sequential, if-then-else)
       const overallCondition = new SequentialCondition({
         conditionVariables: [
           {
-            varName: 'rpc',
-            condition: testRpcConditionObj,
+            varName: 'compound-1',
+            condition: {
+              conditionType: CompoundConditionType,
+              operator: 'and',
+              operands: [
+                testRpcConditionObj,
+                testTimeConditionObj,
+                testContractConditionObj,
+                testJsonApiConditionObj,
+                testJsonRpcConditionObj,
+              ],
+            },
           },
           {
-            varName: 'time',
-            condition: testTimeConditionObj,
-          },
-          {
-            varName: 'contract',
-            condition: testContractConditionObj,
-          },
-          {
-            varName: 'compound',
+            varName: 'compound-2',
             condition: {
               conditionType: CompoundConditionType,
               operator: 'or',
               operands: [
-                testJsonApiConditionObj,
-                testJsonRpcConditionObj,
-                testSigningObjectAbiAttributeConditionObj,
-                testSigningObjectAttributeConditionObj,
+                {
+                  ...testJsonApiConditionObj,
+                  authorizationToken: ':authToken',
+                },
+                {
+                  ...testJsonApiConditionObj,
+                  authorizationToken: ':authToken',
+                  authorizationType: 'Bearer',
+                },
+                {
+                  ...testJsonApiConditionObj,
+                  authorizationToken: ':authToken',
+                  authorizationType: 'X-API-Key',
+                },
+                {
+                  ...testJsonRpcConditionObj,
+                  authorizationToken: ':otherAuthToken',
+                  authorizationType: 'Basic',
+                },
+                testJWTConditionObj,
               ],
             },
           },
@@ -84,15 +105,9 @@ describe.skipIf(!process.env.RUNNING_IN_CI)(
             varName: 'ifThenElse',
             condition: {
               conditionType: IfThenElseConditionType,
-              ifCondition: testJWTConditionObj,
-              thenCondition: {
-                ...testJsonApiConditionObj,
-                authorizationToken: ':authToken',
-              },
-              elseCondition: {
-                ...testJsonRpcConditionObj,
-                authorizationToken: ':otherAuthToken',
-              },
+              ifCondition: testSigningObjectAttributeConditionObj,
+              thenCondition: testSigningObjectAbiAttributeConditionObj,
+              elseCondition: false,
             },
           },
         ],

--- a/packages/taco/schema-docs/condition-schemas.md
+++ b/packages/taco/schema-docs/condition-schemas.md
@@ -36,6 +36,16 @@ _(\*) Required._
 
 _String which is a valid URL._
 
+## JsonAuthorizationType
+
+The type of authorization to use when making the request.
+
+_Enum string, one of the following possible values:_
+
+- `'Bearer'`
+- `'Basic'`
+- `'X-API-Key'`
+
 ## JsonPath
 
 A string containing either a valid JSON Path Expression, or a Context Parameter.
@@ -149,6 +159,7 @@ _Object containing the following properties:_
 | `parameters`               | _Object with dynamic keys of type_ `string` _and values of type_ `unknown` (_optional & nullable_) |              |
 | `query`                    | [JsonPath](#jsonpath)                                                                              |              |
 | `authorizationToken`       | [ContextParam](#contextparam)                                                                      |              |
+| `authorizationType`        | [JsonAuthorizationType](#jsonauthorizationtype)                                                    |              |
 | **`returnValueTest`** (\*) | [ReturnValueTest](#returnvaluetest)                                                                |              |
 
 _(\*) Required._
@@ -165,6 +176,7 @@ _Object containing the following properties:_
 | `params`                   | `Array<unknown>` _or_ _Object with dynamic keys of type_ `string` _and values of type_ `unknown` (_optional & nullable_) |              |
 | `query`                    | [JsonPath](#jsonpath)                                                                                                    |              |
 | `authorizationToken`       | [ContextParam](#contextparam)                                                                                            |              |
+| `authorizationType`        | [JsonAuthorizationType](#jsonauthorizationtype)                                                                          |              |
 | **`returnValueTest`** (\*) | [ReturnValueTest](#returnvaluetest)                                                                                      |              |
 
 _(\*) Required._
@@ -275,7 +287,7 @@ _Object containing the following properties:_
 
 | Property                  | Description                                                                   | Type                                    | Default                     |
 | :------------------------ | :---------------------------------------------------------------------------- | :-------------------------------------- | :-------------------------- |
-| `conditionType`           |                                                                               | `'abi-attribute'`                       | `'abi-attribute'`           |
+| `conditionType`           |                                                                               | `'signing-abi-attribute'`               | `'signing-abi-attribute'`   |
 | `signingObjectContextVar` | The context variable that will be replaced with the signing object at signing | `':signingConditionObject'`             | `':signingConditionObject'` |
 | **`attributeName`** (\*)  | The name of the attribute to check                                            | `string` (_min length: 1_)              |                             |
 | **`abiValidation`** (\*)  | A map of allowed ABI calls with their respective parameter validations.       | [AbiCallValidation](#abicallvalidation) |                             |
@@ -288,7 +300,7 @@ _Object containing the following properties:_
 
 | Property                   | Description                                                                   | Type                                                    | Default                     |
 | :------------------------- | :---------------------------------------------------------------------------- | :------------------------------------------------------ | :-------------------------- |
-| `conditionType`            |                                                                               | `'attribute'`                                           | `'attribute'`               |
+| `conditionType`            |                                                                               | `'signing-attribute'`                                   | `'signing-attribute'`       |
 | `signingObjectContextVar`  | The context variable that will be replaced with the signing object at signing | `':signingConditionObject'`                             | `':signingConditionObject'` |
 | **`attributeName`** (\*)   | The name of the attribute to check                                            | `string` (_min length: 1_)                              |                             |
 | **`returnValueTest`** (\*) |                                                                               | [BlockchainReturnValueTest](#blockchainreturnvaluetest) |                             |

--- a/packages/taco/src/conditions/schemas/common.ts
+++ b/packages/taco/src/conditions/schemas/common.ts
@@ -85,7 +85,14 @@ export const jsonPathSchema = z
   );
 
 const validateHttpsURL = (url: string): boolean => {
-  return URL.canParse(url) && url.startsWith('https://');
+  try {
+    const parsedUrl = new URL(url);
+    // Check if the URL is valid and uses HTTPS
+    return parsedUrl.protocol === 'https:';
+  } catch (e) {
+    // If URL constructor throws, the URL is invalid
+    return false;
+  }
 };
 
 export const jsonAuthorizationTypeSchema = z

--- a/packages/taco/src/conditions/schemas/common.ts
+++ b/packages/taco/src/conditions/schemas/common.ts
@@ -88,11 +88,9 @@ const validateHttpsURL = (url: string): boolean => {
   return URL.canParse(url) && url.startsWith('https://');
 };
 
-export const jsonAuthorizationTypeSchema = z.enum([
-  'Bearer',
-  'Basic',
-  'X-API-Key',
-]);
+export const jsonAuthorizationTypeSchema = z
+  .enum(['Bearer', 'Basic', 'X-API-Key'])
+  .describe('The type of authorization to use when making the request.');
 
 // Use our own URL refinement check due to https://github.com/colinhacks/zod/issues/2236
 export const httpsURLSchema = z

--- a/packages/taco/src/conditions/schemas/common.ts
+++ b/packages/taco/src/conditions/schemas/common.ts
@@ -88,6 +88,12 @@ const validateHttpsURL = (url: string): boolean => {
   return URL.canParse(url) && url.startsWith('https://');
 };
 
+export const jsonAuthorizationTypeSchema = z.enum([
+  'Bearer',
+  'Basic',
+  'X-API-Key',
+]);
+
 // Use our own URL refinement check due to https://github.com/colinhacks/zod/issues/2236
 export const httpsURLSchema = z
   .string()

--- a/packages/taco/src/conditions/schemas/json-api.ts
+++ b/packages/taco/src/conditions/schemas/json-api.ts
@@ -1,18 +1,41 @@
 import { z } from 'zod';
 
-import { baseConditionSchema, httpsURLSchema, jsonPathSchema } from './common';
+import {
+  baseConditionSchema,
+  httpsURLSchema,
+  jsonAuthorizationTypeSchema,
+  jsonPathSchema,
+} from './common';
 import { contextParamSchema } from './context';
 import { returnValueTestSchema } from './return-value-test';
 
 export const JsonApiConditionType = 'json-api';
 
-export const jsonApiConditionSchema = baseConditionSchema.extend({
-  conditionType: z.literal(JsonApiConditionType).default(JsonApiConditionType),
-  endpoint: httpsURLSchema,
-  parameters: z.record(z.string(), z.unknown()).optional(),
-  query: jsonPathSchema.optional(),
-  authorizationToken: contextParamSchema.optional(),
-  returnValueTest: returnValueTestSchema, // Update to allow multiple return values after expanding supported methods
-});
+export const jsonApiConditionSchema = baseConditionSchema
+  .extend({
+    conditionType: z
+      .literal(JsonApiConditionType)
+      .default(JsonApiConditionType),
+    endpoint: httpsURLSchema,
+    parameters: z.record(z.string(), z.unknown()).optional(),
+    query: jsonPathSchema.optional(),
+    authorizationToken: contextParamSchema.optional(),
+    authorizationType: jsonAuthorizationTypeSchema.optional(),
+    returnValueTest: returnValueTestSchema, // Update to allow multiple return values after expanding supported methods
+  })
+  .refine(
+    (data) => {
+      // Ensure that if authorizationType is provided, then authorizationToken is set
+      if (data.authorizationType && !data.authorizationToken) {
+        return false;
+      }
+      return true;
+    },
+    {
+      message:
+        'authorizationToken must be provided if authorizationType is set',
+      path: ['authorizationType'],
+    },
+  );
 
 export type JsonApiConditionProps = z.infer<typeof jsonApiConditionSchema>;

--- a/packages/taco/src/conditions/schemas/json-rpc.ts
+++ b/packages/taco/src/conditions/schemas/json-rpc.ts
@@ -1,22 +1,45 @@
 import { z } from 'zod';
 
-import { baseConditionSchema, httpsURLSchema, jsonPathSchema } from './common';
+import {
+  baseConditionSchema,
+  httpsURLSchema,
+  jsonAuthorizationTypeSchema,
+  jsonPathSchema,
+} from './common';
 import { contextParamSchema } from './context';
 import { returnValueTestSchema } from './return-value-test';
 
 export const JsonRpcConditionType = 'json-rpc';
 
-export const jsonRpcConditionSchema = baseConditionSchema.extend({
-  conditionType: z.literal(JsonRpcConditionType).default(JsonRpcConditionType),
-  endpoint: httpsURLSchema,
-  method: z.string(),
-  // list or dictionary
-  params: z
-    .union([z.array(z.unknown()), z.record(z.string(), z.unknown())])
-    .optional(),
-  query: jsonPathSchema.optional(),
-  authorizationToken: contextParamSchema.optional(),
-  returnValueTest: returnValueTestSchema,
-});
+export const jsonRpcConditionSchema = baseConditionSchema
+  .extend({
+    conditionType: z
+      .literal(JsonRpcConditionType)
+      .default(JsonRpcConditionType),
+    endpoint: httpsURLSchema,
+    method: z.string(),
+    // list or dictionary
+    params: z
+      .union([z.array(z.unknown()), z.record(z.string(), z.unknown())])
+      .optional(),
+    query: jsonPathSchema.optional(),
+    authorizationToken: contextParamSchema.optional(),
+    authorizationType: jsonAuthorizationTypeSchema.optional(),
+    returnValueTest: returnValueTestSchema,
+  })
+  .refine(
+    (data) => {
+      // Ensure that if authorizationType is provided, then authorizationToken is set
+      if (data.authorizationType && !data.authorizationToken) {
+        return false;
+      }
+      return true;
+    },
+    {
+      message:
+        'authorizationToken must be provided if authorizationType is set',
+      path: ['authorizationType'],
+    },
+  );
 
 export type JsonRpcConditionProps = z.infer<typeof jsonRpcConditionSchema>;

--- a/packages/taco/test/conditions/base/json-api.test.ts
+++ b/packages/taco/test/conditions/base/json-api.test.ts
@@ -76,6 +76,59 @@ describe('JsonApiCondition', () => {
       });
     });
 
+    describe('authorizationType', () => {
+      it.each(['Bearer', 'Basic', 'X-API-Key'])(
+        'accepts valid authorization types',
+        (authType) => {
+          const result = JsonApiCondition.validate(jsonApiConditionSchema, {
+            ...testJsonApiConditionObj,
+            authorizationToken: ':authToken',
+            authorizationType: authType,
+          });
+          expect(result.error).toBeUndefined();
+          expect(result.data).toEqual({
+            ...testJsonApiConditionObj,
+            authorizationToken: ':authToken',
+            authorizationType: authType,
+          });
+        },
+      );
+      it('authorizationToken must be set if authorizationType is provided', () => {
+        const result = JsonApiCondition.validate(jsonApiConditionSchema, {
+          ...testJsonApiConditionObj,
+          authorizationType: 'Bearer',
+        });
+        expect(result.error).toBeDefined();
+        expect(result.data).toBeUndefined();
+        expect(result.error?.format()).toMatchObject({
+          authorizationType: {
+            _errors: [
+              'authorizationToken must be provided if authorizationType is set',
+            ],
+          },
+        });
+      });
+      it.each(['InvalidType', 'Bearer ', 'Basic123', 'Y-API-Key'])(
+        'rejects invalid authorization types',
+        (authType) => {
+          const result = JsonApiCondition.validate(jsonApiConditionSchema, {
+            ...testJsonApiConditionObj,
+            authorizationToken: ':authToken',
+            authorizationType: authType,
+          });
+          expect(result.error).toBeDefined();
+          expect(result.data).toBeUndefined();
+          expect(result.error?.format()).toMatchObject({
+            authorizationType: {
+              _errors: [
+                `Invalid enum value. Expected 'Bearer' | 'Basic' | 'X-API-Key', received '${authType}'`,
+              ],
+            },
+          });
+        },
+      );
+    });
+
     describe('parameters', () => {
       it('accepts conditions without query path', () => {
         const { query, ...noQueryObj } = testJsonApiConditionObj;

--- a/packages/taco/test/conditions/base/json-rpc.test.ts
+++ b/packages/taco/test/conditions/base/json-rpc.test.ts
@@ -74,6 +74,58 @@ describe('JsonRpcCondition', () => {
         });
       });
     });
+    describe('authorizationType', () => {
+      it.each(['Bearer', 'Basic', 'X-API-Key'])(
+        'accepts valid authorization types',
+        (authType) => {
+          const result = JsonRpcCondition.validate(jsonRpcConditionSchema, {
+            ...testJsonRpcConditionObj,
+            authorizationToken: ':authToken',
+            authorizationType: authType,
+          });
+          expect(result.error).toBeUndefined();
+          expect(result.data).toEqual({
+            ...testJsonRpcConditionObj,
+            authorizationToken: ':authToken',
+            authorizationType: authType,
+          });
+        },
+      );
+      it('authorizationToken must be set if authorizationType is provided', () => {
+        const result = JsonRpcCondition.validate(jsonRpcConditionSchema, {
+          ...testJsonRpcConditionObj,
+          authorizationType: 'Basic',
+        });
+        expect(result.error).toBeDefined();
+        expect(result.data).toBeUndefined();
+        expect(result.error?.format()).toMatchObject({
+          authorizationType: {
+            _errors: [
+              'authorizationToken must be provided if authorizationType is set',
+            ],
+          },
+        });
+      });
+      it.each(['InvalidType', 'Bearer ', 'Basic123', 'Y-API-Key'])(
+        'rejects invalid authorization types',
+        (authType) => {
+          const result = JsonRpcCondition.validate(jsonRpcConditionSchema, {
+            ...testJsonRpcConditionObj,
+            authorizationToken: ':authToken',
+            authorizationType: authType,
+          });
+          expect(result.error).toBeDefined();
+          expect(result.data).toBeUndefined();
+          expect(result.error?.format()).toMatchObject({
+            authorizationType: {
+              _errors: [
+                `Invalid enum value. Expected 'Bearer' | 'Basic' | 'X-API-Key', received '${authType}'`,
+              ],
+            },
+          });
+        },
+      );
+    });
 
     describe('properties', () => {
       it('accepts conditions without query path', () => {


### PR DESCRIPTION
**Type of PR:**

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [x] Other

**Required reviews:**

- [ ] 1
- [x] 2
- [ ] 3

**What this does:**
Based over #676 

Allows `authorizationType` to be specified for JSON API/RPC conditions. Allowed values are: `Bearer`, `Basic`, `X-API-Key`.

Based on work done in `nucypher` - https://github.com/nucypher/nucypher/pull/3614

**Issues fixed/closed:**

> - Fixes #...

**Why it's needed:**

> Explain how this PR fits in the greater context of the NuCypher Network. E.g.,
> if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**

> What should reviewers focus on? Is there a particular commit/function/section
> of your PR that requires more attention from reviewers?
