### PR TITLE
Signing SDK Updates

### DIFF
--- a/packages/shared/src/porter.ts
+++ b/packages/shared/src/porter.ts
@@ -153,11 +153,7 @@ export type TacoDecryptResult = {
 };
 
 // Signing types
-export type SigningOptions = {
-  optimistic?: boolean; // Whether to return first signatures received or wait for all signatures
-};
-
-type SignResponse = {
+type TacoSignResponse = {
   readonly result: {
     readonly signing_results: {
       readonly signatures: Record<
@@ -169,32 +165,21 @@ type SignResponse = {
   };
 };
 
-export type SignResult = {
-  messageHash: string;
-  aggregatedSignature: string | undefined;
-  signingResults: { [ursulaAddress: string]: [string, string] };
-  errors: Record<string, string>;
-};
-
-function aggregatePorterSignatures(signaturesWithAddress: {
-  [checksumAddress: string]: [string, string];
-}): string {
-  const signatures = Object.values(signaturesWithAddress).map(
-    ([, signature]) => signature,
-  );
-  return signatures.join('');
-}
-
-type DecodedSignature = {
+export type TacoSignature = {
   messageHash: string;
   signature: string;
   signerAddress: string;
 };
 
+export type TacoSignResult = {
+  signingResults: { [ursulaAddress: string]: TacoSignature };
+  errors: Record<string, string>;
+};
+
 function decodeSignature(
   signerAddress: string,
   signatureB64: string,
-): { result?: DecodedSignature; error?: string } {
+): { result?: TacoSignature; error?: string } {
   try {
     const decodedData = JSON.parse(
       new TextDecoder().decode(fromBase64(signatureB64)),
@@ -362,14 +347,13 @@ export class PorterClient {
   public async signUserOp(
     signingRequests: Record<string, string>,
     threshold: number,
-    options: SigningOptions = {},
-  ): Promise<SignResult> {
+  ): Promise<TacoSignResult> {
     const data: Record<string, unknown> = {
       signing_requests: signingRequests,
       threshold: threshold,
     };
 
-    const resp: AxiosResponse<SignResponse> = await this.tryAndCall({
+    const resp: AxiosResponse<TacoSignResponse> = await this.tryAndCall({
       url: '/sign',
       method: 'post',
       data,
@@ -377,79 +361,22 @@ export class PorterClient {
 
     const { signatures, errors } = resp.data.result.signing_results;
     const allErrors: Record<string, string> = { ...errors };
-    const { optimistic = false } = options;
 
-    const signingResults: { [ursulaAddress: string]: [string, string] } = {};
-    let messageHash = '';
-
-    // For non-optimistic path
-    const hashCounts: Map<string, number> = new Map();
-    const hashToSignatures: Map<
-      string,
-      { [ursulaAddress: string]: [string, string] }
-    > = new Map();
-
-    // Single pass: decode signatures and populate signingResults
+    const signingResults: { [ursulaAddress: string]: TacoSignature } = {};
     for (const [ursulaAddress, [signerAddress, signatureB64]] of Object.entries(
       signatures || {},
     )) {
       const decoded = decodeSignature(signerAddress, signatureB64);
       if (decoded.error) {
+        // issue with decoding signature, add to errors
         allErrors[ursulaAddress] = decoded.error;
         continue;
       }
-
-      if (!messageHash) {
-        messageHash = decoded.result!.messageHash;
-      }
-
       // Always include all decoded signatures in signingResults
-      signingResults[ursulaAddress] = [
-        decoded.result!.signerAddress,
-        decoded.result!.signature,
-      ];
-
-      if (!optimistic) {
-        // For non-optimistic: track hashes and group signatures for aggregation
-        const hash = decoded.result!.messageHash;
-        hashCounts.set(hash, (hashCounts.get(hash) || 0) + 1);
-
-        if (!hashToSignatures.has(hash)) {
-          hashToSignatures.set(hash, {});
-        }
-        hashToSignatures.get(hash)![ursulaAddress] = [
-          decoded.result!.signerAddress,
-          decoded.result!.signature,
-        ];
-      }
+      signingResults[ursulaAddress] = decoded.result!;
     }
-
-    // Determine which signatures to aggregate
-    let signaturesToAggregate: { [ursulaAddress: string]: [string, string] } =
-      {};
-
-    if (optimistic) {
-      // Optimistic: aggregate all signatures
-      signaturesToAggregate = signingResults;
-    } else {
-      // Non-optimistic: only aggregate signatures from hash that meets threshold
-      for (const [hash, count] of hashCounts.entries()) {
-        if (count >= threshold) {
-          messageHash = hash;
-          signaturesToAggregate = hashToSignatures.get(hash)!;
-          break;
-        }
-      }
-    }
-
-    const aggregatedSignature =
-      Object.keys(signaturesToAggregate).length >= threshold
-        ? aggregatePorterSignatures(signaturesToAggregate)
-        : undefined;
 
     return {
-      messageHash,
-      aggregatedSignature,
       signingResults,
       errors: allErrors,
     };

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -23,11 +23,9 @@ export const EthAddressSchema = z
   .string()
   .refine(isAddress, { message: 'Invalid Ethereum address' });
 
-export const EthAddressSchemaStrict = z
-  .string()
-  .refine(isAddressStrict, {
-    message: 'Invalid Ethereum address - it must be valid and checksummed',
-  });
+export const EthAddressSchemaStrict = z.string().refine(isAddressStrict, {
+  message: 'Invalid Ethereum address - it must be valid and checksummed',
+});
 
 const BLOCK_HASH_REGEXP = new RegExp('^0x[a-fA-F0-9]{64}$');
 const BlockNumber = z.number().int().nonnegative();

--- a/packages/taco/integration-test/sign.test.ts
+++ b/packages/taco/integration-test/sign.test.ts
@@ -1,4 +1,10 @@
-import { Domain, getPorterUris, UserOperation } from '@nucypher/shared';
+import {
+  Domain,
+  fromHexString,
+  getPorterUris,
+  SigningCoordinatorAgent,
+  UserOperation,
+} from '@nucypher/shared';
 import { ethers } from 'ethers';
 import { beforeAll, describe, expect, test } from 'vitest';
 
@@ -9,7 +15,7 @@ import { signUserOp } from '../src/sign';
 const RPC_PROVIDER_URL = 'https://ethereum-sepolia-rpc.publicnode.com';
 const DUMMY_ADDRESS = '0x742D35Cc6634C0532925A3b8D33c9c0E7B66C8E8';
 const DOMAIN = 'lynx';
-const RITUAL_ID = 1;
+const COHORT_ID = 1;
 const CHAIN_ID = 11155111;
 
 // skip integration test if RUNNING_IN_CI is not set (it is set in CI environments)
@@ -60,7 +66,7 @@ describe.skipIf(!process.env.RUNNING_IN_CI)(
       const signingContext = await context.ConditionContext.forSigningCohort(
         provider,
         DOMAIN as Domain,
-        RITUAL_ID,
+        COHORT_ID,
         CHAIN_ID,
       );
 
@@ -68,7 +74,7 @@ describe.skipIf(!process.env.RUNNING_IN_CI)(
       const signResult = await signUserOp(
         provider,
         DOMAIN as Domain,
-        RITUAL_ID,
+        COHORT_ID,
         CHAIN_ID,
         userOp,
         '0.8.0',
@@ -77,10 +83,19 @@ describe.skipIf(!process.env.RUNNING_IN_CI)(
       );
       console.log('Sign result:', signResult);
 
+      const threshold = await SigningCoordinatorAgent.getThreshold(
+        provider,
+        DOMAIN as Domain,
+        COHORT_ID,
+      );
+
       // Verify sign result
       expect(signResult).toBeDefined();
       expect(signResult.messageHash).toBeDefined();
       expect(signResult.aggregatedSignature).toBeDefined();
+      expect(fromHexString(signResult.aggregatedSignature!).length).toEqual(
+        threshold * 65, // Each signature is 65 bytes (32 bytes r, 32 bytes s, 1 byte v)
+      );
       expect(signResult.signingResults).toBeDefined();
       expect(Object.keys(signResult.signingResults).length).toBeGreaterThan(0);
     }, 15000);

--- a/packages/taco/src/sign.ts
+++ b/packages/taco/src/sign.ts
@@ -1,17 +1,53 @@
 import {
   convertUserOperationToPython,
   Domain,
+  fromHexString,
   getPorterUris,
   PorterClient,
   SigningCoordinatorAgent,
-  SignResult,
+  TacoSignature,
+  TacoSignResult,
   toBase64,
+  toHexString,
   UserOperation,
   UserOperationSignatureRequest,
 } from '@nucypher/shared';
 import { ethers } from 'ethers';
 
 import { ConditionContext } from './conditions/context';
+
+const ERR_INSUFFICIENT_SIGNATURES = (errors: unknown) =>
+  `Threshold of signatures not met; TACo signing failed with errors: ${JSON.stringify(
+    errors,
+  )}`;
+const ERR_MISMATCHED_HASHES = (
+  hashToSignatures: Map<string, { [ursulaAddress: string]: TacoSignature }>,
+) =>
+  `Threshold of signatures not met; multiple mismatched hashes found: ${JSON.stringify(
+    Object.fromEntries(hashToSignatures.entries()),
+  )}`;
+
+export type SignResult = {
+  messageHash: string;
+  aggregatedSignature: string;
+  signingResults: { [ursulaAddress: string]: TacoSignature };
+  errors: Record<string, string>;
+};
+
+function aggregateSignatures(signaturesByAddress: {
+  [checksumAddress: string]: TacoSignature;
+}): string {
+  // Aggregate hex signatures by concatenating them; being carefule to remove the '0x' prefix from each signature except the first one.
+  const signatures = Object.values(signaturesByAddress).map(
+    (sig) => sig.signature,
+  );
+  if (signatures.length === 1) {
+    return signatures[0];
+  }
+  // Concatenate signatures
+  const allBytes = signatures.flatMap((hex) => Array.from(fromHexString(hex)));
+  return `0x${toHexString(new Uint8Array(allBytes))}`;
+}
 
 export async function signUserOp(
   provider: ethers.providers.Provider,
@@ -60,7 +96,65 @@ export async function signUserOp(
   );
 
   // Build signing request for the user operation
-  const result = await porter.signUserOp(signingRequests, threshold);
+  const porterSignResult: TacoSignResult = await porter.signUserOp(
+    signingRequests,
+    threshold,
+  );
 
-  return result;
+  const hashToSignatures: Map<
+    string,
+    { [ursulaAddress: string]: TacoSignature }
+  > = new Map();
+
+  // Single pass: decode signatures and populate signingResults
+  for (const [ursulaAddress, signature] of Object.entries(
+    porterSignResult.signingResults || {},
+  )) {
+    // For non-optimistic: track hashes and group signatures for aggregation
+    const hash = signature.messageHash;
+    if (!hashToSignatures.has(hash)) {
+      hashToSignatures.set(hash, {});
+    }
+    hashToSignatures.get(hash)![ursulaAddress] = signature;
+  }
+
+  let messageHash = undefined;
+  let signaturesToAggregate = undefined;
+  for (const [hash, signatures] of hashToSignatures.entries()) {
+    if (Object.keys(signatures).length >= threshold) {
+      signaturesToAggregate = signatures;
+      messageHash = hash;
+      break;
+    }
+  }
+
+  // Insufficient signatures for a message hash to meet the threshold
+  if (!messageHash || !signaturesToAggregate) {
+    // TODO: think more about this logic
+    if (
+      porterSignResult.errors &&
+      Object.keys(porterSignResult.errors).length > signers.length - threshold
+    ) {
+      // too many errors to achieve threshold
+      throw new Error(ERR_INSUFFICIENT_SIGNATURES(porterSignResult.errors));
+    } else if (hashToSignatures.size > 1) {
+      // If we have multiple hashes, it means we have mismatched hashes from different nodes
+      // we don't really expect this to happen (other than some malicious nodes)
+      throw new Error(ERR_MISMATCHED_HASHES(hashToSignatures));
+      // since there weren't too many errors, the issue is likely hashes
+    } else {
+      throw new Error(
+        ERR_INSUFFICIENT_SIGNATURES(porterSignResult.errors || {}),
+      );
+    }
+  }
+
+  const aggregatedSignature = aggregateSignatures(signaturesToAggregate);
+
+  return {
+    messageHash,
+    aggregatedSignature,
+    signingResults: porterSignResult.signingResults || {},
+    errors: porterSignResult.errors || {},
+  };
 }

--- a/packages/taco/src/sign.ts
+++ b/packages/taco/src/sign.ts
@@ -69,7 +69,6 @@ export async function signUserOp(
     domain,
     cohortId,
   );
-  console.log({ signers });
 
   const threshold = await SigningCoordinatorAgent.getThreshold(
     provider,
@@ -130,18 +129,16 @@ export async function signUserOp(
 
   // Insufficient signatures for a message hash to meet the threshold
   if (!messageHash || !signaturesToAggregate) {
-    // TODO: think more about this logic
     if (
-      porterSignResult.errors &&
-      Object.keys(porterSignResult.errors).length > signers.length - threshold
+      hashToSignatures.size > 1 &&
+      Object.keys(porterSignResult.errors || {}).length <
+        signers.length - threshold
     ) {
-      // too many errors to achieve threshold
-      throw new Error(ERR_INSUFFICIENT_SIGNATURES(porterSignResult.errors));
-    } else if (hashToSignatures.size > 1) {
-      // If we have multiple hashes, it means we have mismatched hashes from different nodes
-      // we don't really expect this to happen (other than some malicious nodes)
+      // Two things are true:
+      // 1. we have multiple hashes, which means we have mismatched hashes from different nodes
+      //    we don't really expect this to happen (other than some malicious nodes)
+      // 2. number of errors still could have allowed for a threshold of signatures
       throw new Error(ERR_MISMATCHED_HASHES(hashToSignatures));
-      // since there weren't too many errors, the issue is likely hashes
     } else {
       throw new Error(
         ERR_INSUFFICIENT_SIGNATURES(porterSignResult.errors || {}),

--- a/packages/taco/src/sign.ts
+++ b/packages/taco/src/sign.ts
@@ -37,7 +37,7 @@ export type SignResult = {
 function aggregateSignatures(signaturesByAddress: {
   [checksumAddress: string]: TacoSignature;
 }): string {
-  // Aggregate hex signatures by concatenating them; being carefule to remove the '0x' prefix from each signature except the first one.
+  // Aggregate hex signatures by concatenating them; being careful to remove the '0x' prefix from each signature except the first one.
   const signatures = Object.values(signaturesByAddress).map(
     (sig) => sig.signature,
   );
@@ -107,7 +107,7 @@ export async function signUserOp(
 
   // Single pass: decode signatures and populate signingResults
   for (const [ursulaAddress, signature] of Object.entries(
-    porterSignResult.signingResults || {},
+    porterSignResult.signingResults,
   )) {
     // For non-optimistic: track hashes and group signatures for aggregation
     const hash = signature.messageHash;
@@ -131,18 +131,19 @@ export async function signUserOp(
   if (!messageHash || !signaturesToAggregate) {
     if (
       hashToSignatures.size > 1 &&
-      Object.keys(porterSignResult.errors || {}).length <
-        signers.length - threshold
+      Object.keys(porterSignResult.errors).length < signers.length - threshold
     ) {
       // Two things are true:
       // 1. we have multiple hashes, which means we have mismatched hashes from different nodes
       //    we don't really expect this to happen (other than some malicious nodes)
       // 2. number of errors still could have allowed for a threshold of signatures
+      console.error(
+        'Porter returned mismatched message hashes:',
+        hashToSignatures,
+      );
       throw new Error(ERR_MISMATCHED_HASHES(hashToSignatures));
     } else {
-      throw new Error(
-        ERR_INSUFFICIENT_SIGNATURES(porterSignResult.errors || {}),
-      );
+      throw new Error(ERR_INSUFFICIENT_SIGNATURES(porterSignResult.errors));
     }
   }
 
@@ -151,7 +152,7 @@ export async function signUserOp(
   return {
     messageHash,
     aggregatedSignature,
-    signingResults: porterSignResult.signingResults || {},
-    errors: porterSignResult.errors || {},
+    signingResults: porterSignResult.signingResults,
+    errors: porterSignResult.errors,
   };
 }

--- a/packages/taco/test/taco-sign.test.ts
+++ b/packages/taco/test/taco-sign.test.ts
@@ -21,8 +21,8 @@ describe('TACo Signing', () => {
       porterSignUserOpMock,
     );
     vi.spyOn(SigningCoordinatorAgent, 'getParticipants').mockResolvedValue([
-      { operator: '0xsnr1', provider: '0xnode1', signature: '0xdead' },
-      { operator: '0xsnr2', provider: '0xnode2', signature: '0xbeef' },
+      { operator: '0xsnr1', provider: '0xnode1', signature: '0xa' },
+      { operator: '0xsnr2', provider: '0xnode2', signature: '0xb' },
     ]);
     vi.spyOn(SigningCoordinatorAgent, 'getThreshold').mockResolvedValue(2);
   });
@@ -210,6 +210,13 @@ describe('TACo Signing', () => {
     });
 
     it('should handle insufficient matched hashes in Porter response', async () => {
+      // set up 3 signers - it matters based on how mismatched hashes are handled
+      vi.spyOn(SigningCoordinatorAgent, 'getParticipants').mockResolvedValue([
+        { operator: '0xsnr1', provider: '0xnode1', signature: '0xa' },
+        { operator: '0xsnr2', provider: '0xnode2', signature: '0xb' },
+        { operator: '0xsnr3', provider: '0xnode3', signature: '0xc' },
+      ]);
+
       const signingResults = {
         '0xnode1': {
           messageHash: '0xhash1',

--- a/packages/taco/test/taco-sign.test.ts
+++ b/packages/taco/test/taco-sign.test.ts
@@ -116,7 +116,6 @@ describe('TACo Signing', () => {
           messageHash: '0xhash1',
           aggregatedSignature: '0xdeadbeef',
           signingResults,
-          errors,
         });
       },
     );
@@ -289,7 +288,6 @@ describe('TACo Signing', () => {
         messageHash: '0xhash1',
         aggregatedSignature: '0xdead',
         signingResults,
-        errors,
       });
     });
 
@@ -340,7 +338,6 @@ describe('TACo Signing', () => {
         messageHash: '0xhash1',
         aggregatedSignature: '0xdeadbeef',
         signingResults,
-        errors,
       });
     });
   });


### PR DESCRIPTION
**Type of PR:**

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [x] Other

**Required reviews:**

- [ ] 1
- [x] 2
- [ ] 3

**What this does:**

Based over #677 

- Refactor `PorterClient` to focus solely on communicating with the Porter instance i.e. sending input and returning output, without performing additional response processing. It should only handle marshalling and unmarshalling data, leaving all logic beyond that to the caller.
- Shift all post-processing logic from `PorterClient` to the `sign` module to streamline `PorterClient` responsibilities.
- Eliminate the `SigningOption` concept, as signature thresholding and hash verification are always required for `signUserOp` to produce a meaningful result.
- Fix signature aggregation by properly combining signature byte arrays instead of concatenating hex strings, which previously introduced a bug that duplicated `0x` prefixes in the result.
- Clearly differentiate failure cases when an aggregated signature cannot be produced due to either excessive errors or mismatched `messageHash` values across Porter responses. While mismatched hashes are an edge case (potentially due to malicious nodes), they are explicitly handled. In either scenario, the `sign` API will raise an error.

**Issues fixed/closed:**
Follow-up to #664 