### PR TITLE
Add JsonCondition support

### DIFF
--- a/packages/taco/integration-test/condition-lingo.test.ts
+++ b/packages/taco/integration-test/condition-lingo.test.ts
@@ -175,8 +175,7 @@ describe.skipIf(!process.env.RUNNING_IN_CI)(
       await validateConditionExpression(conditionExpr);
     }, 15000);
 
-    test.skip('validate json condition structure', async () => {
-      // TODO: Enable once JsonCondition is deployed to Lynx nodes
+    test('validate json condition structure', async () => {
       const jsonCondition = new conditions.base.json.JsonCondition(
         testJsonConditionObj,
       );

--- a/packages/taco/integration-test/condition-lingo.test.ts
+++ b/packages/taco/integration-test/condition-lingo.test.ts
@@ -18,6 +18,7 @@ import {
   testContextVariableConditionObj,
   testContractConditionObj,
   testJsonApiConditionObj,
+  testJsonConditionObj,
   testJsonRpcConditionObj,
   testJWTConditionObj,
   testRpcConditionObj,
@@ -171,6 +172,15 @@ describe.skipIf(!process.env.RUNNING_IN_CI)(
           testContextVariableConditionObj,
         );
       const conditionExpr = new ConditionExpression(contextVariableCondition);
+      await validateConditionExpression(conditionExpr);
+    }, 15000);
+
+    test.skip('validate json condition structure', async () => {
+      // TODO: Enable once JsonCondition is deployed to Lynx nodes
+      const jsonCondition = new conditions.base.json.JsonCondition(
+        testJsonConditionObj,
+      );
+      const conditionExpr = new ConditionExpression(jsonCondition);
       await validateConditionExpression(conditionExpr);
     }, 15000);
   },

--- a/packages/taco/integration-test/encrypt-decrypt.test.ts
+++ b/packages/taco/integration-test/encrypt-decrypt.test.ts
@@ -285,16 +285,17 @@ describe.skipIf(!process.env.RUNNING_IN_CI)(
       const message = toBytes(messageString);
 
       // Create a context variable condition that checks if userAddress is in allowlist
-      const contextVariableCondition = new conditions.base.contextVariable.ContextVariableCondition({
-        ...testContextVariableConditionObj,
-        returnValueTest: {
-          comparator: 'in',
-          value: [
-            CONSUMER_ADDRESS.toLowerCase(),
-            '0x0000000000000000000000000000000000000001',
-          ],
-        },
-      });
+      const contextVariableCondition =
+        new conditions.base.contextVariable.ContextVariableCondition({
+          ...testContextVariableConditionObj,
+          returnValueTest: {
+            comparator: 'in',
+            value: [
+              CONSUMER_ADDRESS.toLowerCase(),
+              '0x0000000000000000000000000000000000000001',
+            ],
+          },
+        });
 
       expect(contextVariableCondition.requiresAuthentication()).toBe(true);
 
@@ -342,16 +343,17 @@ describe.skipIf(!process.env.RUNNING_IN_CI)(
       const message = toBytes(messageString);
 
       // Create a context variable condition with specific allowed addresses
-      const restrictedContextVariableCondition = new conditions.base.contextVariable.ContextVariableCondition({
-        ...testContextVariableConditionObj,
-        returnValueTest: {
-          comparator: 'in',
-          value: [
-            '0x0000000000000000000000000000000000000001', // Not our consumer address
-            '0x0000000000000000000000000000000000000002',
-          ],
-        },
-      });
+      const restrictedContextVariableCondition =
+        new conditions.base.contextVariable.ContextVariableCondition({
+          ...testContextVariableConditionObj,
+          returnValueTest: {
+            comparator: 'in',
+            value: [
+              '0x0000000000000000000000000000000000000001', // Not our consumer address
+              '0x0000000000000000000000000000000000000002',
+            ],
+          },
+        });
 
       const messageKit = await encrypt(
         provider,
@@ -374,6 +376,104 @@ describe.skipIf(!process.env.RUNNING_IN_CI)(
         USER_ADDRESS_PARAM_DEFAULT,
         authProvider,
       );
+
+      await expect(
+        decrypt(provider, DOMAIN, messageKitFromBytes, conditionContext),
+      ).rejects.toThrow();
+    }, 20000);
+
+    test('should encrypt and decrypt with JsonCondition using context variable', async () => {
+      const messageString = 'This message is protected by JsonCondition 🔐';
+      const message = toBytes(messageString);
+
+      // JSON data that will be provided at decryption time
+      const jsonData = {
+        store: {
+          book: [
+            { price: 10.5, category: 'fiction' },
+            { price: 8.99, category: 'non-fiction' },
+          ],
+        },
+      };
+
+      // Create JsonCondition that checks price of first book
+      const jsonCondition = new conditions.base.json.JsonCondition({
+        conditionType: 'json',
+        data: ':jsonData',
+        query: '$.store.book[0].price',
+        returnValueTest: {
+          comparator: '==',
+          value: 10.5,
+        },
+      });
+
+      const messageKit = await encrypt(
+        provider,
+        DOMAIN,
+        message,
+        jsonCondition,
+        RITUAL_ID,
+        encryptorSigner,
+      );
+
+      const encryptedBytes = messageKit.toBytes();
+      const messageKitFromBytes = ThresholdMessageKit.fromBytes(encryptedBytes);
+      const conditionContext =
+        conditions.context.ConditionContext.fromMessageKit(messageKitFromBytes);
+
+      expect(
+        conditionContext.requestedContextParameters.has(':jsonData'),
+      ).toBeTruthy();
+
+      // Provide the JSON data as a custom context parameter
+      conditionContext.addCustomContextParameterValues({
+        ':jsonData': jsonData,
+      });
+
+      const decryptedBytes = await decrypt(
+        provider,
+        DOMAIN,
+        messageKitFromBytes,
+        conditionContext,
+      );
+      const decryptedMessageString = fromBytes(decryptedBytes);
+
+      expect(decryptedMessageString).toEqual(messageString);
+    }, 20000);
+
+    test('should fail to decrypt with JsonCondition when JSON data does not match', async () => {
+      const messageString = 'This should fail with wrong JSON data';
+      const message = toBytes(messageString);
+
+      // Create JsonCondition expecting specific price
+      const jsonCondition = new conditions.base.json.JsonCondition({
+        conditionType: 'json',
+        data: ':productData',
+        query: '$.price',
+        returnValueTest: {
+          comparator: '>',
+          value: 100,
+        },
+      });
+
+      const messageKit = await encrypt(
+        provider,
+        DOMAIN,
+        message,
+        jsonCondition,
+        RITUAL_ID,
+        encryptorSigner,
+      );
+
+      const encryptedBytes = messageKit.toBytes();
+      const messageKitFromBytes = ThresholdMessageKit.fromBytes(encryptedBytes);
+      const conditionContext =
+        conditions.context.ConditionContext.fromMessageKit(messageKitFromBytes);
+
+      // Provide JSON data that doesn't meet the condition (price <= 100)
+      conditionContext.addCustomContextParameterValues({
+        ':productData': { price: 50 },
+      });
 
       await expect(
         decrypt(provider, DOMAIN, messageKitFromBytes, conditionContext),

--- a/packages/taco/schema-docs/condition-schemas.md
+++ b/packages/taco/schema-docs/condition-schemas.md
@@ -186,6 +186,19 @@ _Object containing the following properties:_
 
 _(\*) Required._
 
+## JsonCondition
+
+_Object containing the following properties:_
+
+| Property                   | Description                                                                                  | Type                                              | Default  |
+| :------------------------- | :------------------------------------------------------------------------------------------- | :------------------------------------------------ | :------- |
+| `conditionType`            |                                                                                              | `'json'`                                          | `'json'` |
+| **`data`** (\*)            | Context variable that resolves to JSON data at decryption time.                              | `string` (_regex: `/^:[a-zA-Z_][a-zA-Z0-9_]*$/`_) |          |
+| `query`                    | Optional JSONPath query to extract a specific value from the data.                           | [JsonPath](#jsonpath)                             |          |
+| **`returnValueTest`** (\*) | Test to perform on a value. Supports comparison operators like ==, >, <, >=, <=, !=, in, !in | [ReturnValueTest](#returnvaluetest)               |          |
+
+_(\*) Required._
+
 ## JsonApiCondition
 
 _Object containing the following properties:_

--- a/packages/taco/src/conditions/base/index.ts
+++ b/packages/taco/src/conditions/base/index.ts
@@ -4,6 +4,7 @@
 export * as contextVariable from './context-variable';
 export * as contract from './contract';
 export * as ecdsa from './ecdsa';
+export * as json from './json';
 export * as jsonApi from './json-api';
 export * as jsonRpc from './json-rpc';
 export * as jwt from './jwt';

--- a/packages/taco/src/conditions/base/json.ts
+++ b/packages/taco/src/conditions/base/json.ts
@@ -1,0 +1,22 @@
+import { Condition } from '../condition';
+import {
+  JsonConditionProps,
+  jsonConditionSchema,
+  JsonConditionType,
+} from '../schemas/json';
+import { OmitConditionType } from '../shared';
+
+export {
+  JsonConditionProps,
+  jsonConditionSchema,
+  JsonConditionType,
+} from '../schemas/json';
+
+export class JsonCondition extends Condition {
+  constructor(value: OmitConditionType<JsonConditionProps>) {
+    super(jsonConditionSchema, {
+      conditionType: JsonConditionType,
+      ...value,
+    });
+  }
+}

--- a/packages/taco/src/conditions/condition-factory.ts
+++ b/packages/taco/src/conditions/condition-factory.ts
@@ -14,6 +14,11 @@ import {
   ECDSAConditionType,
 } from './base/ecdsa';
 import {
+  JsonCondition,
+  JsonConditionProps,
+  JsonConditionType,
+} from './base/json';
+import {
   JsonApiCondition,
   JsonApiConditionProps,
   JsonApiConditionType,
@@ -70,6 +75,8 @@ export class ConditionFactory {
         return new ContractCondition(props as ContractConditionProps);
       case ECDSAConditionType:
         return new ECDSACondition(props as ECDSAConditionProps);
+      case JsonConditionType:
+        return new JsonCondition(props as JsonConditionProps);
       case JsonApiConditionType:
         return new JsonApiCondition(props as JsonApiConditionProps);
       case JsonRpcConditionType:

--- a/packages/taco/src/conditions/schemas/export-for-zod-doc-gen.ts
+++ b/packages/taco/src/conditions/schemas/export-for-zod-doc-gen.ts
@@ -14,6 +14,7 @@ export * from './context-variable';
 export * from './contract';
 export * from './ecdsa';
 export * from './if-then-else';
+export * from './json';
 export * from './json-api';
 export * from './json-rpc';
 export * from './jwt';

--- a/packages/taco/src/conditions/schemas/json.ts
+++ b/packages/taco/src/conditions/schemas/json.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod';
+
+import { baseConditionSchema, jsonPathSchema } from './common';
+import { returnValueTestSchema } from './return-value-test';
+
+export const JsonConditionType = 'json';
+
+export const jsonConditionSchema = baseConditionSchema.extend({
+  conditionType: z.literal(JsonConditionType).default(JsonConditionType),
+  data: z.any().describe('The JSON data to evaluate. Can be an object, array, primitive value, or JSON string.'),
+  query: jsonPathSchema.optional().describe('Optional JSONPath query to extract a specific value from the data.'),
+  returnValueTest: returnValueTestSchema,
+});
+
+export type JsonConditionProps = z.infer<typeof jsonConditionSchema>;

--- a/packages/taco/src/conditions/schemas/json.ts
+++ b/packages/taco/src/conditions/schemas/json.ts
@@ -1,14 +1,21 @@
 import { z } from 'zod';
 
 import { baseConditionSchema, jsonPathSchema } from './common';
+import { contextParamSchema } from './context';
 import { returnValueTestSchema } from './return-value-test';
 
 export const JsonConditionType = 'json';
 
 export const jsonConditionSchema = baseConditionSchema.extend({
   conditionType: z.literal(JsonConditionType).default(JsonConditionType),
-  data: z.any().describe('The JSON data to evaluate. Can be an object, array, primitive value, or JSON string.'),
-  query: jsonPathSchema.optional().describe('Optional JSONPath query to extract a specific value from the data.'),
+  data: contextParamSchema.describe(
+    'Context variable that resolves to JSON data at decryption time.',
+  ),
+  query: jsonPathSchema
+    .optional()
+    .describe(
+      'Optional JSONPath query to extract a specific value from the data.',
+    ),
   returnValueTest: returnValueTestSchema,
 });
 

--- a/packages/taco/test/conditions/base/json.test.ts
+++ b/packages/taco/test/conditions/base/json.test.ts
@@ -11,17 +11,12 @@ import {
 describe('JsonCondition', () => {
   describe('validation', () => {
     it.each([
-      [
-        'object',
-        { store: { book: [{ price: 10.5 }] } },
-        '$.store.book[0].price',
-        10.5,
-      ],
-      ['array', [1, 2, 3, 4, 5], '$[2]', 3],
-      ['number', 42, undefined, 42],
-      ['string', 'hello world', undefined, 'hello world'],
-      ['boolean', true, undefined, true],
-    ])('accepts valid schema with %s data', (_, data, query, expectedValue) => {
+      [{ store: { book: [{ price: 10.5 }] } }, '$.store.book[0].price', 10.5],
+      [[1, 2, 3, 4, 5], '$[2]', 3],
+      [42, undefined, 42],
+      ['hello world', undefined, 'hello world'],
+      [true, undefined, true],
+    ])('accepts valid schema with data: %j', (data, query, expectedValue) => {
       const testJsonConditionObj: JsonConditionProps = {
         conditionType: JsonConditionType,
         data,
@@ -39,6 +34,28 @@ describe('JsonCondition', () => {
 
       expect(result.error).toBeUndefined();
       expect(result.data).toEqual(testJsonConditionObj);
+    });
+
+    it('accepts JSON-looking string as string data (not parsed as JSON)', () => {
+      const jsonString = '{ "store": { "book": [{ "price": 10.5 }] } }';
+      const testJsonConditionObj: JsonConditionProps = {
+        conditionType: JsonConditionType,
+        data: jsonString,
+        returnValueTest: {
+          comparator: '==',
+          value: jsonString,
+        },
+      };
+
+      const result = JsonCondition.validate(
+        jsonConditionSchema,
+        testJsonConditionObj,
+      );
+
+      expect(result.error).toBeUndefined();
+      expect(result.data).toEqual(testJsonConditionObj);
+      // Verify it's still a string, not parsed
+      expect(typeof result.data?.data).toBe('string');
     });
 
     describe('query validation', () => {

--- a/packages/taco/test/conditions/base/json.test.ts
+++ b/packages/taco/test/conditions/base/json.test.ts
@@ -1,0 +1,104 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { describe, expect, it } from 'vitest';
+
+import {
+  JsonCondition,
+  JsonConditionProps,
+  jsonConditionSchema,
+  JsonConditionType,
+} from '../../../src/conditions/base/json';
+
+describe('JsonCondition', () => {
+  describe('validation', () => {
+    it.each([
+      [
+        'object',
+        { store: { book: [{ price: 10.5 }] } },
+        '$.store.book[0].price',
+        10.5,
+      ],
+      ['array', [1, 2, 3, 4, 5], '$[2]', 3],
+      ['number', 42, undefined, 42],
+      ['string', 'hello world', undefined, 'hello world'],
+      ['boolean', true, undefined, true],
+    ])('accepts valid schema with %s data', (_, data, query, expectedValue) => {
+      const testJsonConditionObj: JsonConditionProps = {
+        conditionType: JsonConditionType,
+        data,
+        query,
+        returnValueTest: {
+          comparator: '==',
+          value: expectedValue,
+        },
+      };
+
+      const result = JsonCondition.validate(
+        jsonConditionSchema,
+        testJsonConditionObj,
+      );
+
+      expect(result.error).toBeUndefined();
+      expect(result.data).toEqual(testJsonConditionObj);
+    });
+
+    describe('query validation', () => {
+      it.each([
+        '$.store.book[0].price',
+        '$[2]',
+        '$.prices.usd',
+        '$.store.book[*].price',
+        '$..price',
+      ])('accepts valid JSONPath query: %s', (query) => {
+        const result = JsonCondition.validate(jsonConditionSchema, {
+          conditionType: JsonConditionType,
+          data: { test: 'data' },
+          query,
+          returnValueTest: { comparator: '==', value: 0 },
+        });
+
+        expect(result.error).toBeUndefined();
+      });
+
+      it.each(['not-a-jsonpath', '$..[', 'random string'])(
+        'rejects invalid JSONPath query: %s',
+        (query) => {
+          const result = JsonCondition.validate(jsonConditionSchema, {
+            conditionType: JsonConditionType,
+            data: { test: 'data' },
+            query,
+            returnValueTest: { comparator: '==', value: 0 },
+          });
+
+          expect(result.error).toBeDefined();
+          const errorMessages = result.error?.errors.map((err) => err.message);
+          expect(
+            errorMessages?.includes('Invalid JSONPath expression'),
+          ).toBeTruthy();
+        },
+      );
+    });
+
+    describe('context variables', () => {
+      it('allows context variables in query and return value test', () => {
+        const result = JsonCondition.validate(jsonConditionSchema, {
+          conditionType: JsonConditionType,
+          data: { prices: { usd: 100 } },
+          query: '$.prices.:currency',
+          returnValueTest: { comparator: '==', value: ':expectedValue' },
+        });
+
+        expect(result.error).toBeUndefined();
+      });
+    });
+
+    it('rejects invalid condition type', () => {
+      const result = JsonCondition.validate(jsonConditionSchema, {
+        conditionType: 'invalid-type',
+        data: { test: 'data' },
+        returnValueTest: { comparator: '==', value: 0 },
+      } as unknown as JsonConditionProps);
+
+      expect(result.error).toBeDefined();
+    });
+  });
+});

--- a/packages/taco/test/conditions/base/json.test.ts
+++ b/packages/taco/test/conditions/base/json.test.ts
@@ -10,20 +10,14 @@ import {
 
 describe('JsonCondition', () => {
   describe('validation', () => {
-    it.each([
-      [{ store: { book: [{ price: 10.5 }] } }, '$.store.book[0].price', 10.5],
-      [[1, 2, 3, 4, 5], '$[2]', 3],
-      [42, undefined, 42],
-      ['hello world', undefined, 'hello world'],
-      [true, undefined, true],
-    ])('accepts valid schema with data: %j', (data, query, expectedValue) => {
+    it('accepts valid schema with context variable data', () => {
       const testJsonConditionObj: JsonConditionProps = {
         conditionType: JsonConditionType,
-        data,
-        query,
+        data: ':jsonData',
+        query: '$.store.book[0].price',
         returnValueTest: {
           comparator: '==',
-          value: expectedValue,
+          value: 10.5,
         },
       };
 
@@ -36,14 +30,13 @@ describe('JsonCondition', () => {
       expect(result.data).toEqual(testJsonConditionObj);
     });
 
-    it('accepts JSON-looking string as string data (not parsed as JSON)', () => {
-      const jsonString = '{ "store": { "book": [{ "price": 10.5 }] } }';
+    it('accepts valid schema without query', () => {
       const testJsonConditionObj: JsonConditionProps = {
         conditionType: JsonConditionType,
-        data: jsonString,
+        data: ':jsonData',
         returnValueTest: {
           comparator: '==',
-          value: jsonString,
+          value: 42,
         },
       };
 
@@ -54,8 +47,24 @@ describe('JsonCondition', () => {
 
       expect(result.error).toBeUndefined();
       expect(result.data).toEqual(testJsonConditionObj);
-      // Verify it's still a string, not parsed
-      expect(typeof result.data?.data).toBe('string');
+    });
+
+    it('rejects non-context variable data', () => {
+      const testJsonConditionObj = {
+        conditionType: JsonConditionType,
+        data: { store: { book: [{ price: 10.5 }] } },
+        returnValueTest: {
+          comparator: '==',
+          value: 10.5,
+        },
+      };
+
+      const result = JsonCondition.validate(
+        jsonConditionSchema,
+        testJsonConditionObj as unknown as JsonConditionProps,
+      );
+
+      expect(result.error).toBeDefined();
     });
 
     describe('query validation', () => {
@@ -68,7 +77,7 @@ describe('JsonCondition', () => {
       ])('accepts valid JSONPath query: %s', (query) => {
         const result = JsonCondition.validate(jsonConditionSchema, {
           conditionType: JsonConditionType,
-          data: { test: 'data' },
+          data: ':jsonData',
           query,
           returnValueTest: { comparator: '==', value: 0 },
         });
@@ -81,7 +90,7 @@ describe('JsonCondition', () => {
         (query) => {
           const result = JsonCondition.validate(jsonConditionSchema, {
             conditionType: JsonConditionType,
-            data: { test: 'data' },
+            data: ':jsonData',
             query,
             returnValueTest: { comparator: '==', value: 0 },
           });
@@ -96,10 +105,10 @@ describe('JsonCondition', () => {
     });
 
     describe('context variables', () => {
-      it('allows context variables in query and return value test', () => {
+      it('allows context variables in data, query and return value test', () => {
         const result = JsonCondition.validate(jsonConditionSchema, {
           conditionType: JsonConditionType,
-          data: { prices: { usd: 100 } },
+          data: ':priceData',
           query: '$.prices.:currency',
           returnValueTest: { comparator: '==', value: ':expectedValue' },
         });

--- a/packages/taco/test/test-utils.ts
+++ b/packages/taco/test/test-utils.ts
@@ -55,6 +55,10 @@ import {
   ECDSAConditionType,
 } from '../src/conditions/base/ecdsa';
 import {
+  JsonConditionProps,
+  JsonConditionType,
+} from '../src/conditions/base/json';
+import {
   JsonApiConditionProps,
   JsonApiConditionType,
 } from '../src/conditions/base/json-api';
@@ -274,6 +278,16 @@ export const testTimeConditionObj: TimeConditionProps = {
   },
   method: TimeConditionMethod,
   chain: TEST_CHAIN_ID,
+};
+
+export const testJsonConditionObj: JsonConditionProps = {
+  conditionType: JsonConditionType,
+  data: { store: { book: [{ price: 10.5 }] } },
+  query: '$.store.book[0].price',
+  returnValueTest: {
+    comparator: '==',
+    value: 10.5,
+  },
 };
 
 export const testJsonApiConditionObj: JsonApiConditionProps = {

--- a/packages/taco/test/test-utils.ts
+++ b/packages/taco/test/test-utils.ts
@@ -282,7 +282,7 @@ export const testTimeConditionObj: TimeConditionProps = {
 
 export const testJsonConditionObj: JsonConditionProps = {
   conditionType: JsonConditionType,
-  data: { store: { book: [{ price: 10.5 }] } },
+  data: ':jsonData',
   query: '$.store.book[0].price',
   returnValueTest: {
     comparator: '==',


### PR DESCRIPTION
Implements JsonCondition to match the new condition type added to nucypher - https://github.com/nucypher/nucypher/pull/3656

## What
Adds support for evaluating JSON data directly without HTTP requests. Unlike JsonApiCondition which fetches data from an endpoint, JsonCondition accepts JSON data inline.

## Implementation
- **Schema**: `jsonConditionSchema` with `data` (any type), optional `query` (JSONPath), and `returnValueTest`
- **Class**: `JsonCondition` extends base `Condition` class
- **Factory**: Registered in `ConditionFactory` for deserialization
- **Tests**: 15 unit tests + integration test for backend validation

## Use Cases
- Evaluating static JSON data
- Testing conditions without external dependencies  
- Inline data conditions in multi-condition logic