### PR TITLE
fix: handle missing chain and ENS registry in viem-ethers adapter

### DIFF
--- a/packages/shared/src/viem/ethers-adapter.ts
+++ b/packages/shared/src/viem/ethers-adapter.ts
@@ -15,6 +15,10 @@ function createNetworkish(chain: Chain): ethers.providers.Networkish {
   // Add ENS registry address if available
   if (chain.contracts?.ensRegistry?.address) {
     networkish.ensAddress = chain.contracts.ensRegistry.address;
+  } else {
+    console.warn(
+      `No ENS registry found on chain ${chain.name} (chainId=${chain.id}) at chain.contracts.ensRegistry.address. Resolving ENS will not work on the created ethers Provider.`,
+    );
   }
 
   return networkish;
@@ -41,11 +45,10 @@ export function viemClientToProvider(
 ): ethers.providers.Provider {
   const { chain, transport }: PublicClient = client;
 
-  if (!chain) {
-    throw new Error('Client must have a chain configured');
+  let networkish: ethers.providers.Networkish | undefined;
+  if (chain) {
+    networkish = createNetworkish(chain);
   }
-
-  const networkish = createNetworkish(chain);
 
   // Note: We read minimal, commonly-present properties from transport.
   // viem's transport internals are not a public API and may change.

--- a/packages/shared/src/viem/ethers-adapter.ts
+++ b/packages/shared/src/viem/ethers-adapter.ts
@@ -17,7 +17,11 @@ function createNetworkish(chain: Chain): ethers.providers.Networkish {
     networkish.ensAddress = chain.contracts.ensRegistry.address;
   } else {
     console.warn(
-      `No ENS registry found on chain ${chain.name} (chainId=${chain.id}) at chain.contracts.ensRegistry.address. Resolving ENS will not work on the created ethers Provider.`,
+      `No ENS registry found on chain ${chain.name} (chainId=${chain.id}).\n` +
+        `With the current configuration, ENS resolution will not work on the created ethers Provider.\n` +
+        `To fix this either:\n` +
+        `  - Set chain.contracts.ensRegistry.address to the correct ENS registry address, or\n` +
+        `  - Or omit the \`chain\` data to allow automatic ENS registry detection from the provider.`,
     );
   }
 

--- a/packages/shared/test/viem-ethers-adapter.test.ts
+++ b/packages/shared/test/viem-ethers-adapter.test.ts
@@ -109,9 +109,7 @@ describe('viem ethers adapter', () => {
       };
 
       const clientWithoutChain = createPublicClient(clientWithoutChainConfig);
-      expect(() => viemClientToProvider(clientWithoutChain)).toThrow(
-        'Client must have a chain configured',
-      );
+      expect(() => viemClientToProvider(clientWithoutChain)).not.toThrow();
     });
 
     it('should handle missing transport URL', () => {

--- a/packages/taco/integration-test/viem-to-ethers-ens.test.ts
+++ b/packages/taco/integration-test/viem-to-ethers-ens.test.ts
@@ -1,30 +1,21 @@
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 
 import { toEthersProvider } from '@nucypher/shared';
 import { createPublicClient, http } from 'viem';
 import { mainnet } from 'viem/chains';
 
-describe.skipIf(!process.env.RUNNING_IN_CI)('Viem-Ethers Adapter Integration Tests', () => {
-  describe('ENS Registry', () => {
-    // TODO: will fix this in a different PR - issue #712
-    test.skip('should properly read ENS registry contract address from viem client converted to ethers provider', async () => {
+describe.skipIf(!process.env.RUNNING_IN_CI)(
+  'Viem-Ethers Adapter ENS Integration Tests',
+  () => {
+    test('should properly resolve ENS name to address when no viem chain object is provided', async () => {
       // Test with chain that has ENS registry (mainnet)
       // Note: mainnet from viem/chains includes ENS registry configuration
       const mainnetViemClient = createPublicClient({
-        chain: mainnet,
         transport: http('https://eth.llamarpc.com'),
       });
 
       // Convert to ethers provider to verify ENS address mapping
       const ethersProvider = toEthersProvider(mainnetViemClient);
-
-      // Verify ENS registry is properly mapped from viem chain configuration
-      const expectedEnsAddress = mainnet.contracts?.ensRegistry?.address;
-      expect(ethersProvider.network.ensAddress).toBe(expectedEnsAddress);
-      // Also verify it's the known mainnet ENS registry address
-      expect(ethersProvider.network.ensAddress).toBe(
-        '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e',
-      );
 
       // Test actual ENS name resolution to verify functionality
       const resolvedAddress = await ethersProvider.resolveName('vitalik.eth');
@@ -32,6 +23,68 @@ describe.skipIf(!process.env.RUNNING_IN_CI)('Viem-Ethers Adapter Integration Tes
       // Currently vitalik.eth is "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045".
       // But it may change in the future. So we only check if it's a valid Ethereum address.
       expect(resolvedAddress).toMatch(/^0x[a-fA-F0-9]{40}$/); // Valid Ethereum address format
+
+      // Currently ethersProvider.network.ensAddress on mainnet is "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e".
+      expect(ethersProvider.network.ensAddress).toBeTruthy();
     }, 15000);
-  });
-});
+
+    test('should properly handle viem chain with explicit ENS registry configuration', async () => {
+      const chainWithEns = {
+        ...mainnet,
+        contracts: {
+          ...mainnet.contracts,
+          ensRegistry: {
+            // Manually providing ENS registry since viem/chains doesn't include it
+            address:
+              '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e' as `0x${string}`,
+          },
+        },
+      };
+
+      const mainnetViemClient = createPublicClient({
+        chain: chainWithEns,
+        transport: http(),
+      });
+
+      // Convert to ethers provider to verify ENS address mapping
+      const ethersProvider = toEthersProvider(mainnetViemClient);
+
+      // Don't check for console.warn since the behavior might vary
+      // The important part is that ENS registry is properly set when provided
+
+      // Verify ENS registry address is properly set
+      expect(ethersProvider.network.ensAddress).toBe(
+        '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e',
+      );
+
+      // Test actual ENS name resolution to verify functionality
+      const resolvedAddress = await ethersProvider.resolveName('vitalik.eth');
+      expect(resolvedAddress).toBeTruthy();
+      expect(resolvedAddress).toMatch(/^0x[a-fA-F0-9]{40}$/); // Valid Ethereum address format
+    }, 15000);
+
+    test('should warn when viem chain lacks ENS registry configuration', async () => {
+      // mainnet from viem/chains does NOT include ensRegistry, only ensUniversalResolver
+      const mainnetViemClient = createPublicClient({
+        chain: mainnet,
+        transport: http(),
+      });
+
+      const consoleSpy = vi.spyOn(console, 'warn');
+
+      // Convert to ethers provider
+      const ethersProvider = toEthersProvider(mainnetViemClient);
+
+      // Should trigger warning since mainnet doesn't have ensRegistry in viem/chains
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining('No ENS registry found on chain'),
+      );
+
+      // ENS address should not be set
+      expect(ethersProvider.network.ensAddress).toBeUndefined();
+
+      // Clean up the spy
+      consoleSpy.mockRestore();
+    });
+  },
+);


### PR DESCRIPTION
**Type of PR:**

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:**

- [ ] 1
- [ ] 2
- [x] 3

**What this does:**

This PR improves ENS resolution handling in the viem-to-ethers adapter by:
- Making the `chain` parameter optional in [viemClientToProvider()](cci:1://file:///Users/funcy/repos/taco/taco-web/packages/shared/src/viem/ethers-adapter.ts:26:0-123:1) to support viem clients without an explicit chain configuration
- Adding a developer-friendly warning when ENS registry is not available on the configured chain
- Adding comprehensive integration tests covering three ENS resolution scenarios:
  1. When no viem chain object is provided (ethers will automatically use the provider's default chain)
  2. When viem chain has explicit ENS registry configuration 
  3. When viem chain lacks ENS registry configuration (mainnet from viem/chains)

**Issues fixed/closed:**

 - Fixes https://github.com/nucypher/taco-web/issues/712

**Notes for reviewers:**

The adapter was previously requiring a chain configuration even when not strictly necessary, and failing silently when ENS wasn't properly configured.
But in last viem version the `contracts.ensRegistry.address` is not filled. For main net for example, it contain:
```
mainnet.contracts: {
  "ensUniversalResolver": {
    "address": "0xeeeeeeee14d718c2b47d9923deab1335e144eeee",
    "blockCreated": 23085558
  },
  "multicall3": {
    "address": "0xca11bde05977b3631167028862be2a173976ca11",
    "blockCreated": 14353601
  }
}
```

- So if viem `contracts.ensRegistry.address` was not provided, the ethers `networkish.ensAddress` would not be filled and a console.warn will be logged. Because otherwise using ensUniversalResolver to get the ensRegistry will require an async contract function call.
- But, if viem `contracts.ensRegistry.address` was explicitly filled by the user, it will be utilized to fill `networkish.ensAddress`. 
- However, if the user passed just the url or an http provider, without filling the `chain` property. Then ethers.js will automatically fill the ensAddress and work with no issue. **And this is the most likely case to happen.**

The tests should describe the 3 mentioned cases well.

And the behavior would be documented when working at https://github.com/nucypher/sprints/issues/265.
