### PR TITLE
Chore: few final touches on epic-viem

### DIFF
--- a/packages/shared/src/viem/ethers-adapter.ts
+++ b/packages/shared/src/viem/ethers-adapter.ts
@@ -13,16 +13,10 @@ function createNetworkish(chain: Chain): ethers.providers.Networkish {
   };
 
   // Add ENS registry address if available
+  // Note that it is not available by default in the last viem version. But also ENS is not used at taco for the user address (:useraddress).
+  // Therefore, no need to take any action if the ENS registry address is not available.
   if (chain.contracts?.ensRegistry?.address) {
     networkish.ensAddress = chain.contracts.ensRegistry.address;
-  } else {
-    console.warn(
-      `No ENS registry found on chain ${chain.name} (chainId=${chain.id}).\n` +
-        `With the current configuration, ENS resolution will not work on the created ethers Provider.\n` +
-        `To fix this either:\n` +
-        `  - Set chain.contracts.ensRegistry.address to the correct ENS registry address, or\n` +
-        `  - Or omit the \`chain\` data to allow automatic ENS registry detection from the provider.`,
-    );
   }
 
   return networkish;

--- a/packages/shared/test/viem-ethers-adapter.test.ts
+++ b/packages/shared/test/viem-ethers-adapter.test.ts
@@ -175,10 +175,6 @@ describe('viem ethers adapter', () => {
   describe('toEthersProvider', () => {
     it('should create provider from viem client', async () => {
       const viemClient = createPublicClient({
-        chain: {
-          id: 80002,
-          name: 'Polygon Amoy',
-        },
         transport: http('https://test.com'),
       });
       const provider = toEthersProvider(viemClient);

--- a/packages/shared/test/viem-types.test.ts
+++ b/packages/shared/test/viem-types.test.ts
@@ -8,7 +8,6 @@ describe('viem types', () => {
     const viemLikeClient: PublicClient = {
       getChainId: () => Promise.resolve(80002),
       call: (params: any) => Promise.resolve('0x1234'),
-      chain: { name: 'Polygon Amoy', id: 80002 },
     } as any;
 
     expect(viemLikeClient.getChainId).toBeDefined();

--- a/packages/taco/README.md
+++ b/packages/taco/README.md
@@ -173,12 +173,11 @@ const viemAccount = privateKeyToAccount('0x...');
 const accessClient = new AccessClient({
   domain: DOMAIN_NAMES.TESTNET, // TESTNET -> 'tapir'
   ritualId: 6,
-  viemClient,
-  viemAccount
+  viemClient
 });
 
 // Encrypt data
-const messageKit = await accessClient.encrypt('Hello, secret!', condition);
+const messageKit = await accessClient.encrypt('Hello, secret!', condition, viemAccount);
 
 // Decrypt
 const conditionContext = ConditionContext.fromMessageKit(messageKit);
@@ -201,17 +200,17 @@ import { AccessClient, DOMAIN_NAMES } from '@nucypher/taco';
 const accessClientViem = new AccessClient({
   domain: DOMAIN_NAMES.TESTNET,
   ritualId: 6,
-  viemClient,
-  viemAccount
+  viemClient
 });
+const messageKit = await accessClientViem.encrypt(data, condition, viemAccount);
 
 // With ethers.js
 const accessClientEthers = new AccessClient({
   domain: DOMAIN_NAMES.TESTNET,
   ritualId: 6,
-  ethersProvider,
-  ethersSigner
+  ethersProvider
 });
+const messageKit2 = await accessClientEthers.encrypt(data, condition, ethersSigner);
 ```
 
 ## Learn more

--- a/packages/taco/integration-test/access-client.test.ts
+++ b/packages/taco/integration-test/access-client.test.ts
@@ -50,7 +50,6 @@ describe.skipIf(!process.env.RUNNING_IN_CI)(
     });
     const viemTestConfig: ViemTestConfig = {
       viemClient: viemPublicClient,
-      viemSignerAccount: encryptorAccount,
     };
 
     // Create ethers clients for correct network (Polygon Amoy)
@@ -68,7 +67,6 @@ describe.skipIf(!process.env.RUNNING_IN_CI)(
 
     const ethersTestConfig: EthersTestConfig = {
       ethersProvider,
-      ethersSigner: encryptorSigner,
     };
 
     beforeAll(async () => {
@@ -108,23 +106,19 @@ describe.skipIf(!process.env.RUNNING_IN_CI)(
 
     const createAuthProvider = (
       config: ViemTestConfig | EthersTestConfig,
-      customSigner?: ethers.Wallet | LocalAccount,
+      customSigner: ethers.Wallet | LocalAccount,
     ) => {
       const provider =
         (config as EthersTestConfig).ethersProvider ??
         (config as ViemTestConfig).viemClient;
-      const signerToUse =
-        customSigner ??
-        (config as EthersTestConfig).ethersSigner ??
-        (config as ViemTestConfig).viemSignerAccount;
 
-      return new EIP4361AuthProvider(provider, signerToUse as any);
+      return new EIP4361AuthProvider(provider, customSigner as any);
     };
 
     const setupConditionContext = async (
       messageKit: ThresholdMessageKit,
       config: ViemTestConfig | EthersTestConfig,
-      customSigner?: ethers.Wallet | LocalAccount,
+      customSigner: ethers.Wallet | LocalAccount,
     ) => {
       const conditionContext =
         conditions.context.ConditionContext.fromMessageKit(messageKit);
@@ -141,112 +135,120 @@ describe.skipIf(!process.env.RUNNING_IN_CI)(
     describe
       .skipIf(!process.env.RUNNING_IN_CI)
       .each<
-        | ['ethers', EthersTestConfig, ethers.Wallet]
-        | ['viem', ViemTestConfig, LocalAccount]
+        | ['ethers', EthersTestConfig, ethers.Wallet, ethers.Wallet]
+        | ['viem', ViemTestConfig, LocalAccount, LocalAccount]
       >([
-        ['ethers', ethersTestConfig, consumerSigner],
-        ['viem', viemTestConfig, consumerAccount],
-      ])('TacoClient with %s', (label, objects, consumerSigner) => {
-      test('should encrypt and decrypt a message using standard encrypt method', async () => {
-        // Setup
-        const accessClient = new AccessClient({
-          domain: DOMAIN,
-          ritualId: RITUAL_ID,
-          ...objects,
-        });
+        ['ethers', ethersTestConfig, encryptorSigner, consumerSigner],
+        ['viem', viemTestConfig, encryptorAccount, consumerAccount],
+      ])(
+      'TacoClient with %s',
+      (label, objects, encryptorSigner, consumerSigner) => {
+        test('should encrypt and decrypt a message using standard encrypt method', async () => {
+          // Setup
+          const accessClient = new AccessClient({
+            domain: DOMAIN,
+            ritualId: RITUAL_ID,
+            ...objects,
+          });
 
-        // Create test message and condition
-        const messageString = `This is a secret message from TacoClient with ${label} 🤐`;
-        const message = toBytes(messageString);
-        const condition = createTestCondition();
+          // Create test message and condition
+          const messageString = `This is a secret message from TacoClient with ${label} 🤐`;
+          const message = toBytes(messageString);
+          const condition = createTestCondition();
 
-        // Encrypt the message
-        const messageKit = await accessClient.encrypt(message, condition);
-        expect(messageKit).toBeInstanceOf(ThresholdMessageKit);
-        expect(messageKit.toBytes()).toBeInstanceOf(Uint8Array);
+          // Encrypt the message
+          const messageKit = await accessClient.encrypt(
+            message,
+            condition,
+            encryptorSigner,
+          );
+          expect(messageKit).toBeInstanceOf(ThresholdMessageKit);
+          expect(messageKit.toBytes()).toBeInstanceOf(Uint8Array);
 
-        // Setup condition context for decryption
-        const conditionContext = await setupConditionContext(
-          messageKit,
-          objects,
-          consumerSigner,
-        );
+          // Setup condition context for decryption
+          const conditionContext = await setupConditionContext(
+            messageKit,
+            objects,
+            consumerSigner,
+          );
 
-        // Test decryption with Uint8Array input
-        const decryptedBytes = await accessClient.decrypt(
-          messageKit.toBytes(),
-          conditionContext,
-        );
-        const decryptedMessageString = fromBytes(decryptedBytes);
-        expect(decryptedMessageString).toEqual(messageString);
+          // Test decryption with Uint8Array input
+          const decryptedBytes = await accessClient.decrypt(
+            messageKit.toBytes(),
+            conditionContext,
+          );
+          const decryptedMessageString = fromBytes(decryptedBytes);
+          expect(decryptedMessageString).toEqual(messageString);
 
-        // Test decryption with MessageKit object input
-        const decryptedBytes2 = await accessClient.decrypt(
-          messageKit,
-          conditionContext,
-        );
-        const decryptedMessageString2 = fromBytes(decryptedBytes2);
-        expect(decryptedMessageString2).toEqual(messageString);
-      }, 30000);
+          // Test decryption with MessageKit object input
+          const decryptedBytes2 = await accessClient.decrypt(
+            messageKit,
+            conditionContext,
+          );
+          const decryptedMessageString2 = fromBytes(decryptedBytes2);
+          expect(decryptedMessageString2).toEqual(messageString);
+        }, 30000);
 
-      test('should encrypt and decrypt using offline encryptWithPublicKey method', async () => {
-        // Create AccessClient using the test configuration
-        const accessClient = new AccessClient({
-          domain: DOMAIN,
-          ritualId: RITUAL_ID,
-          ...objects,
-        });
+        test('should encrypt and decrypt using offline encryptWithPublicKey method', async () => {
+          // Create AccessClient using the test configuration
+          const accessClient = new AccessClient({
+            domain: DOMAIN,
+            ritualId: RITUAL_ID,
+            ...objects,
+          });
 
-        const messageString = 'This is an offline encrypted message 🔐';
-        const message = toBytes(messageString);
-        const condition = createTestCondition();
+          const messageString = 'This is an offline encrypted message 🔐';
+          const message = toBytes(messageString);
+          const condition = createTestCondition();
 
-        // Get DKG public key from ritual for offline encryption
-        const dkgRitual = await DkgClient.getActiveRitual(
-          ethersProvider,
-          DOMAIN,
-          RITUAL_ID,
-        );
-        const dkgPublicKey = dkgRitual.dkgPublicKey;
-        expect(dkgPublicKey).toBeDefined();
+          // Get DKG public key from ritual for offline encryption
+          const dkgRitual = await DkgClient.getActiveRitual(
+            ethersProvider,
+            DOMAIN,
+            RITUAL_ID,
+          );
+          const dkgPublicKey = dkgRitual.dkgPublicKey;
+          expect(dkgPublicKey).toBeDefined();
 
-        // Perform offline encryption with DKG public key
-        const messageKit = await accessClient.encryptWithPublicKey(
-          message,
-          condition,
-          dkgPublicKey,
-        );
-        expect(messageKit).toBeInstanceOf(ThresholdMessageKit);
+          // Perform offline encryption with DKG public key
+          const messageKit = await accessClient.encryptWithPublicKey(
+            message,
+            condition,
+            dkgPublicKey,
+            encryptorSigner,
+          );
+          expect(messageKit).toBeInstanceOf(ThresholdMessageKit);
 
-        // Setup condition context with consumer signer for decryption
-        const conditionContext = await setupConditionContext(
-          messageKit,
-          objects,
-          consumerSigner,
-        );
+          // Setup condition context with consumer signer for decryption
+          const conditionContext = await setupConditionContext(
+            messageKit,
+            objects,
+            consumerSigner,
+          );
 
-        // Decrypt and verify
-        const decryptedBytes = await accessClient.decrypt(
-          messageKit,
-          conditionContext,
-        );
-        const decryptedMessageString = fromBytes(decryptedBytes);
-        expect(decryptedMessageString).toEqual(messageString);
-      }, 15000);
+          // Decrypt and verify
+          const decryptedBytes = await accessClient.decrypt(
+            messageKit,
+            conditionContext,
+          );
+          const decryptedMessageString = fromBytes(decryptedBytes);
+          expect(decryptedMessageString).toEqual(messageString);
+        }, 15000);
 
-      test('should successfully validate network configuration', async () => {
-        // Setup
-        const accessClient = new AccessClient({
-          domain: DOMAIN,
-          ritualId: RITUAL_ID,
-          ...objects,
-        });
+        test('should successfully validate network configuration', async () => {
+          // Setup
+          const accessClient = new AccessClient({
+            domain: DOMAIN,
+            ritualId: RITUAL_ID,
+            ...objects,
+          });
 
-        // Validate configuration with network calls
-        const validation = accessClient.validateConfig();
+          // Validate configuration with network calls
+          const validation = accessClient.validateConfig();
 
-        expect(validation).resolves.not.toThrow();
-      }, 10000);
-    });
+          await expect(validation).resolves.not.toThrow();
+        }, 10000);
+      },
+    );
   },
 );

--- a/packages/taco/integration-test/access-client.test.ts
+++ b/packages/taco/integration-test/access-client.test.ts
@@ -8,7 +8,6 @@ import {
 import { ethers } from 'ethers';
 import { createPublicClient, http, LocalAccount } from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';
-import { polygonAmoy } from 'viem/chains';
 import {
   AccessClient,
   AccessClientEthersConfig,
@@ -45,7 +44,6 @@ describe.skipIf(!process.env.RUNNING_IN_CI)(
 
     // Create viem clients for correct network (Polygon Amoy)
     const viemPublicClient = createPublicClient({
-      chain: polygonAmoy,
       transport: http(RPC_PROVIDER_URL),
     });
     const viemTestConfig: ViemTestConfig = {

--- a/packages/taco/integration-test/encrypt-decrypt.test.ts
+++ b/packages/taco/integration-test/encrypt-decrypt.test.ts
@@ -8,7 +8,6 @@ import {
 import { ethers } from 'ethers';
 import { createPublicClient, http, LocalAccount, PublicClient } from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';
-import { polygonAmoy } from 'viem/chains';
 import {
   conditions,
   decrypt,
@@ -43,7 +42,6 @@ describe
     [
       'viem',
       createPublicClient({
-        chain: polygonAmoy,
         transport: http(RPC_PROVIDER_URL),
       }),
       privateKeyToAccount(ENCRYPTOR_PRIVATE_KEY),
@@ -61,7 +59,7 @@ describe
       if (provider instanceof ethers.providers.Provider) {
         chainId = (await provider.getNetwork()).chainId;
       } else {
-        chainId = provider.chain!.id as number;
+        chainId = await provider.getChainId();
       }
       if (chainId !== CHAIN_ID) {
         throw new Error(

--- a/packages/taco/integration-test/viem-to-ethers-ens.test.ts
+++ b/packages/taco/integration-test/viem-to-ethers-ens.test.ts
@@ -71,7 +71,7 @@ describe.skipIf(!process.env.RUNNING_IN_CI)(
         transport: http(),
       });
 
-      const consoleSpy = vi.spyOn(console, 'warn');
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
       // Convert to ethers provider
       const ethersProvider = toEthersProvider(mainnetViemClient);
@@ -87,7 +87,7 @@ describe.skipIf(!process.env.RUNNING_IN_CI)(
       expect(ethersProvider.network.ensAddress).toBeUndefined();
 
       // ENS operation is expected to fail
-      expect(ethersProvider.resolveName('vitalik.eth')).rejects.toThrow(
+      await expect(ethersProvider.resolveName('vitalik.eth')).rejects.toThrow(
         'network does not support ENS',
       );
     });

--- a/packages/taco/integration-test/viem-to-ethers-ens.test.ts
+++ b/packages/taco/integration-test/viem-to-ethers-ens.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, vi } from 'vitest';
+import { describe, expect, test } from 'vitest';
 
 import { toEthersProvider } from '@nucypher/shared';
 import { ethers } from 'ethers';
@@ -27,9 +27,9 @@ describe.skipIf(!process.env.RUNNING_IN_CI)(
 
       // Currently ethersProvider.network.ensAddress on mainnet is "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e".
       expect(ethersProvider.network.ensAddress).toBeTruthy();
-    }, 15000);
+    }, 60000);
 
-    test('should properly handle viem chain with explicit ENS registry configuration', async () => {
+    test('ENS operations should fail when viem chain lacks ENS registry address', async () => {
       const chainWithEns = {
         ...mainnet,
         contracts: {
@@ -50,9 +50,6 @@ describe.skipIf(!process.env.RUNNING_IN_CI)(
       // Convert to ethers provider to verify ENS address mapping
       const ethersProvider = toEthersProvider(mainnetViemClient);
 
-      // Don't check for console.warn since the behavior might vary
-      // The important part is that ENS registry is properly set when provided
-
       // Verify ENS registry address is properly set
       expect(ethersProvider.network.ensAddress).toBe(
         '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e',
@@ -62,26 +59,17 @@ describe.skipIf(!process.env.RUNNING_IN_CI)(
       const resolvedAddress = await ethersProvider.resolveName('vitalik.eth');
       expect(resolvedAddress).toBeTruthy();
       expect(ethers.utils.isAddress(resolvedAddress)).toBe(true); // Valid Ethereum address format
-    }, 15000);
+    }, 60000);
 
-    test('should warn when viem chain lacks ENS registry configuration', async () => {
+    test('expected to fail when viem chain does not contain the ENS registry contract address', async () => {
       // mainnet from viem/chains does NOT include ensRegistry, only ensUniversalResolver
       const mainnetViemClient = createPublicClient({
         chain: mainnet,
         transport: http(),
       });
 
-      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-
       // Convert to ethers provider
       const ethersProvider = toEthersProvider(mainnetViemClient);
-
-      // Should trigger warning since mainnet doesn't have ensRegistry in viem/chains
-      expect(consoleSpy).toHaveBeenCalledWith(
-        expect.stringContaining('No ENS registry found on chain'),
-      );
-      // Clean up the spy
-      consoleSpy.mockRestore();
 
       // ENS address is expected to not be set
       expect(ethersProvider.network.ensAddress).toBeUndefined();

--- a/packages/taco/src/access-client/config-validator.ts
+++ b/packages/taco/src/access-client/config-validator.ts
@@ -158,20 +158,14 @@ export class AccessConfigValidator {
       if (!config.viemClient) {
         errors.push('viemClient is required for viem configuration');
       }
-      if (!config.viemSignerAccount) {
-        errors.push('viemSignerAccount is required for viem configuration');
-      }
     } else if (isEthersAccessClientConfig(config)) {
       // Ethers configuration
       if (!config.ethersProvider) {
         errors.push('ethersProvider is required for ethers configuration');
       }
-      if (!config.ethersSigner) {
-        errors.push('ethersSigner is required for ethers configuration');
-      }
     } else {
       errors.push(
-        'Configuration must include either viem objects (viemClient + viemSignerAccount) or ethers objects (ethersProvider + ethersSigner)',
+        'Configuration must include either viemClient or ethersProvider',
       );
     }
 

--- a/packages/taco/src/access-client/config.ts
+++ b/packages/taco/src/access-client/config.ts
@@ -5,11 +5,7 @@
  * for configuring AccessClient instances with different blockchain client libraries (viem, ethers.js).
  */
 
-import {
-  DomainName,
-  type PublicClient,
-  type SignerAccount,
-} from '@nucypher/shared';
+import { DomainName, type PublicClient } from '@nucypher/shared';
 import type { ethers } from 'ethers';
 
 /**
@@ -30,8 +26,6 @@ interface AccessClientBaseConfig {
 export interface AccessClientViemConfig extends AccessClientBaseConfig {
   /** Viem PublicClient for blockchain operations */
   viemClient: PublicClient;
-  /** Viem SignerAccount for signing operations */
-  viemSignerAccount: SignerAccount;
 }
 
 /**
@@ -40,8 +34,6 @@ export interface AccessClientViemConfig extends AccessClientBaseConfig {
 export interface AccessClientEthersConfig extends AccessClientBaseConfig {
   /** Ethers Provider for blockchain operations */
   ethersProvider: ethers.providers.Provider;
-  /** Ethers Signer for signing operations */
-  ethersSigner: ethers.Signer;
 }
 
 /**
@@ -59,7 +51,7 @@ export type AccessClientConfig =
 export function isViemAccessClientConfig(
   config: AccessClientConfig,
 ): config is AccessClientViemConfig {
-  return 'viemClient' in config && 'viemSignerAccount' in config;
+  return 'viemClient' in config;
 }
 
 /**
@@ -70,5 +62,5 @@ export function isViemAccessClientConfig(
 export function isEthersAccessClientConfig(
   config: AccessClientConfig,
 ): config is AccessClientEthersConfig {
-  return 'ethersProvider' in config && 'ethersSigner' in config;
+  return 'ethersProvider' in config;
 }

--- a/packages/taco/test/access-client.test.ts
+++ b/packages/taco/test/access-client.test.ts
@@ -312,7 +312,7 @@ describe('AccessClient', () => {
       },
     ])('should pass full validation for $description', async ({ config }) => {
       const result = AccessConfigValidator.validate(config());
-      expect(result).resolves.not.toThrow();
+      await expect(result).resolves.not.toThrow();
     });
 
     it('should detect and report missing blockchain dependencies', async () => {

--- a/packages/taco/test/access-client.test.ts
+++ b/packages/taco/test/access-client.test.ts
@@ -1,9 +1,5 @@
 import { DOMAIN_NAMES, DomainName } from '@nucypher/shared';
-import {
-  fakeProvider,
-  fakeViemAccount,
-  fakeViemPublicClient,
-} from '@nucypher/test-utils';
+import { fakeProvider, fakeViemPublicClient } from '@nucypher/test-utils';
 import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
 
 import {
@@ -64,7 +60,6 @@ describe('AccessConfigValidator', () => {
         domain: 'tapir',
         ritualId: 6,
         viemClient: fakeViemPublicClient(),
-        viemSignerAccount: fakeViemAccount(),
       });
 
       expect(result.isValid).toBe(true);
@@ -76,7 +71,6 @@ describe('AccessConfigValidator', () => {
         domain: 'INVALID_DOMAIN' as DomainName,
         ritualId: 999,
         viemClient: fakeViemPublicClient(),
-        viemSignerAccount: fakeViemAccount(),
       });
 
       expect(result.isValid).toBe(false);
@@ -87,7 +81,6 @@ describe('AccessConfigValidator', () => {
       const result = AccessConfigValidator.validateFast({
         ritualId: 6,
         viemClient: fakeViemPublicClient(),
-        viemSignerAccount: fakeViemAccount(),
       } as AccessClientConfig);
 
       expect(result.isValid).toBe(false);
@@ -121,7 +114,6 @@ describe('AccessClient', () => {
       domain: 'tapir',
       ritualId: 6,
       viemClient: fakeViemPublicClient(),
-      viemSignerAccount: fakeViemAccount(),
     };
 
     const ethersProvider = fakeProvider();
@@ -129,7 +121,6 @@ describe('AccessClient', () => {
       domain: 'tapir',
       ritualId: 6,
       ethersProvider,
-      ethersSigner: ethersProvider.getSigner(),
     };
   });
 
@@ -186,12 +177,6 @@ describe('AccessClient', () => {
         description: 'missing viemClient from viem config',
       },
       {
-        configModifications: { viemSignerAccount: undefined },
-        baseConfig: 'viem',
-        expectedError: 'viemSignerAccount is required for viem configuration',
-        description: 'missing viemSignerAccount from viem config',
-      },
-      {
         configModifications: { domain: undefined },
         baseConfig: 'ethers',
         expectedError: 'The property `domain` is required',
@@ -208,12 +193,6 @@ describe('AccessClient', () => {
         baseConfig: 'ethers',
         expectedError: 'ethersProvider is required for ethers configuration',
         description: 'missing ethersProvider from ethers config',
-      },
-      {
-        configModifications: { ethersSigner: undefined },
-        baseConfig: 'ethers',
-        expectedError: 'ethersSigner is required for ethers configuration',
-        description: 'missing ethersSigner from ethers config',
       },
     ])(
       'should throw error for $description',
@@ -234,11 +213,9 @@ describe('AccessClient', () => {
           new AccessClient({
             domain: 'tapir',
             ritualId: 6,
-            viemClient: fakeViemPublicClient(),
-            ethersProvider: fakeProvider(),
           } as unknown as AccessClientConfig),
       ).toThrow(
-        'Invalid configuration: Configuration must include either viem objects (viemClient + viemSignerAccount) or ethers objects (ethersProvider + ethersSigner)',
+        'Invalid configuration: Configuration must include either viemClient or ethersProvider',
       );
     });
   });
@@ -248,13 +225,13 @@ describe('AccessClient', () => {
       {
         configType: 'viem',
         config: () => validViemConfig,
-        expectedProperties: ['viemClient', 'viemSignerAccount'],
+        expectedProperties: ['viemClient'],
         description: 'viem client configuration',
       },
       {
         configType: 'ethers',
         config: () => validEthersConfig,
-        expectedProperties: ['ethersProvider', 'ethersSigner'],
+        expectedProperties: ['ethersProvider'],
         description: 'ethers client configuration',
       },
     ])(
@@ -347,7 +324,7 @@ describe('AccessClient', () => {
 
       expect(result.isValid).toBe(false);
       expect(result.errors).toContain(
-        'Configuration must include either viem objects (viemClient + viemSignerAccount) or ethers objects (ethersProvider + ethersSigner)',
+        'Configuration must include either viemClient or ethersProvider',
       );
     });
 
@@ -370,7 +347,6 @@ describe('AccessClient', () => {
             domain: 'tapir',
             ritualId: -5,
             viemClient: fakeViemPublicClient(),
-            viemSignerAccount: fakeViemAccount(),
           }),
       ).toThrow('Invalid ritual ID');
     });

--- a/packages/test-utils/src/utils.ts
+++ b/packages/test-utils/src/utils.ts
@@ -106,7 +106,6 @@ export const fakeProvider = (
 export const fakeViemPublicClient = (): PublicClient => {
   // Create public client for reading data
   const publicClient = createPublicClient({
-    chain: polygonAmoy,
     transport: custom({
       request: vi.fn().mockImplementation(async ({ method }) => {
         // Network detection calls


### PR DESCRIPTION
**Type of PR:**

- [ ] Bugfix
- [] Feature
- [ ] Documentation
- [x] Other

**Required reviews:**

- [ ] 1
- [ ] 2
- [x] 3

**What this does:**

This PR finalizes the AccessClient API design and viem client test by:

1. (first commit) **Moving signer from constructor to encrypt methods** - The `AccessClient` configuration no longer requires a signer/account during instantiation. Instead, signers are now passed directly to encryption methods where they're actually needed.

**API Changes:**

**Before:**
```typescript
const accessClient = new AccessClient({
  domain: DOMAIN_NAMES.TESTNET,
  ritualId: 6,
  viemClient,
  viemAccount  // ❌ Signer in constructor
});

const messageKit = await accessClient.encrypt('Hello!', condition);
```

**After:**
```typescript
const accessClient = new AccessClient({
  domain: DOMAIN_NAMES.TESTNET,
  ritualId: 6,
  viemClient  // ✅ No signer needed
});

const messageKit = await accessClient.encrypt('Hello!', condition, viemAccount);  // ✅ Signer as parameter
```

**Configuration interfaces updated:**
- Removed `viemAccount` from `AccessClientViemConfig`
- Removed `ethersSigner` from `AccessClientEthersConfig`
- Added `authSigner`/`authAccount` parameters to `encrypt()` and `encryptWithPublicKey()` methods


2. (second commit) **Simplifying test setup** - Removed unnecessary chain configuration from viem client creation across test files.


**Why it's needed:**

This refactor improves the AccessClient API design for several reasons:

1. **Better separation of concerns** - Signers are only required for encryption operations (to authenticate the encryptor), not for decryption or client instantiation. The new API reflects this reality.

2. **Cleaner configuration** - The AccessClient configuration now only contains what's truly needed for the client's core functionality (domain, ritual ID, provider/client). As the signer is not needed directly for `decrypt(...)` function.

And regarding the viem client creation at tests:
1. Passing chain was not really needed.
2. It was casing a warning because the chain passed did not have ensRegistry contract address.

**Notes for reviewers:**

- **Focus areas:**
  - `packages/taco/src/access-client/client.ts` - New encrypt method signatures with overloads for ethers/viem signers
  - `packages/taco/src/access-client/config.ts` - Removal of signer-related properties from config interfaces
  - `packages/taco/README.md` - Updated usage examples
  - `packages/taco/integration-test/access-client.test.ts` - Comprehensive test updates showing the new API pattern
