### PR TITLE
feat(conditions): add :nullAddress as automatically injected context variable

### DIFF
--- a/packages/taco/src/conditions/const.ts
+++ b/packages/taco/src/conditions/const.ts
@@ -12,6 +12,8 @@ export const CONTEXT_PARAM_FULL_MATCH_REGEXP = new RegExp(
 
 export const CONTEXT_PARAM_PREFIX = ':';
 
+export const NULL_ADDRESS_CONTEXT_VAR = ':nullAddress';
+
 export const USER_ADDRESS_PARAMS = [
   // Ordering matters, this should always be last
   USER_ADDRESS_PARAM_DEFAULT,

--- a/packages/taco/src/conditions/context/context.ts
+++ b/packages/taco/src/conditions/context/context.ts
@@ -63,10 +63,12 @@ const EXPECTED_AUTH_PROVIDER_TYPES: Record<string, AuthProviderType[]> = {
 export const AUTOMATICALLY_INJECTED_CONTEXT_PARAMS = [
   // These context parameters are automatically injected on the node side.
   SIGNING_CONDITION_OBJECT_CONTEXT_VAR,
+  ':nullAddress',
 ];
 export const RESERVED_CONTEXT_PARAMS = [
   USER_ADDRESS_PARAM_DEFAULT,
   SIGNING_CONDITION_OBJECT_CONTEXT_VAR,
+  ':nullAddress',
 ];
 
 export class ConditionContext {

--- a/packages/taco/src/conditions/context/context.ts
+++ b/packages/taco/src/conditions/context/context.ts
@@ -18,6 +18,7 @@ import {
   CONTEXT_PARAM_FULL_MATCH_REGEXP,
   CONTEXT_PARAM_PREFIX,
   CONTEXT_PARAM_REGEXP,
+  NULL_ADDRESS_CONTEXT_VAR,
   USER_ADDRESS_PARAMS,
 } from '../const';
 import { SIGNING_CONDITION_OBJECT_CONTEXT_VAR } from '../schemas/signing';
@@ -63,12 +64,12 @@ const EXPECTED_AUTH_PROVIDER_TYPES: Record<string, AuthProviderType[]> = {
 export const AUTOMATICALLY_INJECTED_CONTEXT_PARAMS = [
   // These context parameters are automatically injected on the node side.
   SIGNING_CONDITION_OBJECT_CONTEXT_VAR,
-  ':nullAddress',
+  NULL_ADDRESS_CONTEXT_VAR,
 ];
 export const RESERVED_CONTEXT_PARAMS = [
   USER_ADDRESS_PARAM_DEFAULT,
   SIGNING_CONDITION_OBJECT_CONTEXT_VAR,
-  ':nullAddress',
+  NULL_ADDRESS_CONTEXT_VAR,
 ];
 
 export class ConditionContext {


### PR DESCRIPTION
## Summary

Adds `:nullAddress` as an automatically injected context variable that resolves to the Ethereum null address (0x0000000000000000000000000000000000000000) on the node side.

## Motivation

This is the taco-web companion PR to nucypher/nucypher#3668, which adds the `:nullAddress` protected context variable to the nucypher node implementation.

## Changes

- Add `:nullAddress` to AUTOMATICALLY_INJECTED_CONTEXT_PARAMS array
- Add `:nullAddress` to RESERVED_CONTEXT_PARAMS array to prevent manual setting by users

## Testing

The existing test suite already handles automatically injected parameters:
- Tests verify that automatically injected parameters cannot be manually set
- Tests verify that reserved parameters are properly protected

## Related PRs

- nucypher/nucypher#3668 - Node-side implementation of :nullAddress context variable