### PR TITLE
🐛 fix(taco): add jsonConditionSchema to anyConditionSchema

### DIFF
--- a/packages/taco/schema-docs/condition-schemas.md
+++ b/packages/taco/schema-docs/condition-schemas.md
@@ -9,6 +9,7 @@ _Union of the following possible types:_
 - [ContextVariableCondition](#contextvariablecondition)
 - [ContractCondition](#contractcondition)
 - [EcdsaCondition](#ecdsacondition)
+- [JsonCondition](#jsoncondition)
 - [JsonApiCondition](#jsonapicondition)
 - [JsonRpcCondition](#jsonrpccondition)
 - [JwtCondition](#jwtcondition)

--- a/packages/taco/src/conditions/schemas/utils.ts
+++ b/packages/taco/src/conditions/schemas/utils.ts
@@ -6,6 +6,7 @@ import { contextVariableConditionSchema } from './context-variable';
 import { contractConditionSchema } from './contract';
 import { ecdsaConditionSchema } from './ecdsa';
 import { ifThenElseConditionSchema } from './if-then-else';
+import { jsonConditionSchema } from './json';
 import { jsonApiConditionSchema } from './json-api';
 import { jsonRpcConditionSchema } from './json-rpc';
 import { jwtConditionSchema } from './jwt';
@@ -24,6 +25,7 @@ export const anyConditionSchema: z.ZodSchema = z.lazy(() =>
     contextVariableConditionSchema,
     contractConditionSchema,
     ecdsaConditionSchema,
+    jsonConditionSchema,
     jsonApiConditionSchema,
     jsonRpcConditionSchema,
     jwtConditionSchema,

--- a/packages/taco/test/conditions/any-condition-schema.test.ts
+++ b/packages/taco/test/conditions/any-condition-schema.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  CompoundCondition,
+  compoundConditionSchema,
+  CompoundConditionType,
+} from '../../src/conditions/compound-condition';
+import {
+  testCompoundConditionObj,
+  testContextVariableConditionObj,
+  testContractConditionObj,
+  testECDSAConditionObj,
+  testIfThenElseConditionObj,
+  testJsonApiConditionObj,
+  testJsonConditionObj,
+  testJsonRpcConditionObj,
+  testJWTConditionObj,
+  testRpcConditionObj,
+  testSequentialConditionObj,
+  testSigningObjectAbiAttributeConditionObj,
+  testSigningObjectAttributeConditionObj,
+  testTimeConditionObj,
+} from '../test-utils';
+
+/**
+ * This test ensures that all condition types are included in anyConditionSchema.
+ * If a new condition type is added but not included in anyConditionSchema,
+ * it will fail validation when used inside compound/sequential conditions.
+ *
+ * When adding a new condition type:
+ * 1. Add a test object in test-utils.ts
+ * 2. Add it to the test cases below
+ * 3. Ensure it's imported and added to anyConditionSchema in schemas/utils.ts
+ */
+describe('anyConditionSchema completeness', () => {
+  const allConditionTestObjects = [
+    { name: 'rpc', obj: testRpcConditionObj },
+    { name: 'time', obj: testTimeConditionObj },
+    { name: 'contract', obj: testContractConditionObj },
+    { name: 'contextVariable', obj: testContextVariableConditionObj },
+    { name: 'json', obj: testJsonConditionObj },
+    { name: 'jsonApi', obj: testJsonApiConditionObj },
+    { name: 'jsonRpc', obj: testJsonRpcConditionObj },
+    { name: 'jwt', obj: testJWTConditionObj },
+    { name: 'ecdsa', obj: testECDSAConditionObj },
+    {
+      name: 'signingObjectAttribute',
+      obj: testSigningObjectAttributeConditionObj,
+    },
+    {
+      name: 'signingObjectAbiAttribute',
+      obj: testSigningObjectAbiAttributeConditionObj,
+    },
+    { name: 'compound', obj: testCompoundConditionObj },
+    { name: 'sequential', obj: testSequentialConditionObj },
+    { name: 'ifThenElse', obj: testIfThenElseConditionObj },
+  ];
+
+  it.each(allConditionTestObjects)(
+    'validates $name condition inside compound condition',
+    ({ name, obj }) => {
+      const compoundWithCondition = {
+        conditionType: CompoundConditionType,
+        operator: 'not',
+        operands: [obj],
+      };
+
+      const result = CompoundCondition.validate(
+        compoundConditionSchema,
+        compoundWithCondition,
+      );
+
+      expect(
+        result.error,
+        `${name} condition should be valid inside compound condition. ` +
+          `If this fails, ensure ${name}ConditionSchema is added to anyConditionSchema in schemas/utils.ts`,
+      ).toBeUndefined();
+    },
+  );
+});

--- a/packages/taco/test/test-utils.ts
+++ b/packages/taco/test/test-utils.ts
@@ -88,6 +88,10 @@ import {
   CompoundConditionType,
 } from '../src/conditions/compound-condition';
 import { ConditionExpression } from '../src/conditions/condition-expr';
+import {
+  IfThenElseConditionProps,
+  IfThenElseConditionType,
+} from '../src/conditions/if-then-else-condition';
 import { AddressAllowlistConditionProps } from '../src/conditions/predefined/address-allowlist';
 import { ERC721Balance } from '../src/conditions/predefined/erc721';
 import {
@@ -431,6 +435,13 @@ export const testSequentialConditionObj: SequentialConditionProps = {
       condition: testContractConditionObj,
     },
   ],
+};
+
+export const testIfThenElseConditionObj: IfThenElseConditionProps = {
+  conditionType: IfThenElseConditionType,
+  ifCondition: testRpcConditionObj,
+  thenCondition: testTimeConditionObj,
+  elseCondition: testContractConditionObj,
 };
 
 export const testSigningObjectAttributeConditionObj: SigningObjectAttributeConditionProps =


### PR DESCRIPTION
## Summary

The `json` condition type was missing from the `anyConditionSchema` union in `schemas/utils.ts`, causing validation failures when json conditions were used inside compound or sequential conditions.

## Changes

1. **Bug fix**: Added `jsonConditionSchema` import and included it in the `anyConditionSchema` union
2. **Regression test**: Added `any-condition-schema.test.ts` that validates all 14 condition types can be used inside compound conditions. This prevents future omissions by failing fast with a descriptive error message.

## Testing

- All 14 condition type tests pass
- Type checking passes