### PR TITLE
Add `getSigningCoordinatorChild` to SigningCoordinatorAgent

### DIFF
--- a/packages/shared/src/contracts/agents/signing-coordinator.ts
+++ b/packages/shared/src/contracts/agents/signing-coordinator.ts
@@ -77,6 +77,15 @@ export class SigningCoordinatorAgent {
     );
   }
 
+  public static async getSigningCoordinatorChild(
+    provider: ethers.providers.Provider,
+    domain: Domain,
+    chainId: number,
+  ): Promise<string> {
+    const coordinator = await this.connectReadOnly(provider, domain);
+    return await coordinator.getSigningCoordinatorChild(chainId);
+  }
+
   private static async connectReadOnly(
     provider: ethers.providers.Provider,
     domain: Domain,


### PR DESCRIPTION
**Type of PR:**

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [x] Other

**Required reviews:**

- [ ] 1
- [x] 2
- [ ] 3

**What this does:**

Adds the `getSigningCoordinatorChild` function to the `SigningCoordinatorAgent` so that the address of the relevant `SigningCoordinatorChild` on a chain can be easily obtained.

**Issues fixed/closed:**

> - Fixes #...

**Why it's needed:**

> Explain how this PR fits in the greater context of the NuCypher Network. E.g.,
> if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**

> What should reviewers focus on? Is there a particular commit/function/section
> of your PR that requires more attention from reviewers?
