### PR TITLE
fix(taco): exclude sequential varName references from required context params

### DIFF
--- a/packages/taco/src/conditions/context/context.ts
+++ b/packages/taco/src/conditions/context/context.ts
@@ -20,6 +20,7 @@ import {
   CONTEXT_PARAM_REGEXP,
   USER_ADDRESS_PARAMS,
 } from '../const';
+import { getAllNestedConditionVariableNames } from '../schemas/sequential';
 import { SIGNING_CONDITION_OBJECT_CONTEXT_VAR } from '../schemas/signing';
 
 export type CustomContextParam =
@@ -210,6 +211,12 @@ export class ConditionContext {
   }
 
   private static findContextParameters(condition: ConditionProps) {
+    // Collect internally-defined variable names from sequential conditions
+    // These are scoped within the condition and should not be required as external context
+    const internalVarNames = new Set(
+      getAllNestedConditionVariableNames(condition).map((name) => `:${name}`),
+    );
+
     // find all the context variables we need
     const requestedParameters = new Set<string>();
 
@@ -217,7 +224,10 @@ export class ConditionContext {
     const properties = Object.keys(condition) as (keyof typeof condition)[];
     properties.forEach((prop) => {
       this.findContextParameter(condition[prop]).forEach((contextVar) => {
-        if (!AUTOMATICALLY_INJECTED_CONTEXT_PARAMS.includes(contextVar)) {
+        if (
+          !AUTOMATICALLY_INJECTED_CONTEXT_PARAMS.includes(contextVar) &&
+          !internalVarNames.has(contextVar)
+        ) {
           requestedParameters.add(contextVar);
         }
       });

--- a/packages/taco/src/conditions/context/context.ts
+++ b/packages/taco/src/conditions/context/context.ts
@@ -20,7 +20,7 @@ import {
   CONTEXT_PARAM_REGEXP,
   USER_ADDRESS_PARAMS,
 } from '../const';
-import { getAllNestedConditionVariableNames } from '../schemas/sequential';
+import { ConditionVariableProps } from '../schemas/sequential';
 import { SIGNING_CONDITION_OBJECT_CONTEXT_VAR } from '../schemas/signing';
 import {
   SequentialConditionProps,
@@ -211,11 +211,13 @@ export class ConditionContext {
         'conditionType' in value &&
         value.conditionType === SequentialConditionType
       ) {
-        getAllNestedConditionVariableNames(
-          value as SequentialConditionProps,
-        ).forEach((varName) => {
-          internalContextVariablesFromConditionVariables.add(`:${varName}`);
-        });
+        (value as SequentialConditionProps).conditionVariables.forEach(
+          (variable: ConditionVariableProps) => {
+            internalContextVariablesFromConditionVariables.add(
+              `:${variable.varName}`,
+            );
+          },
+        );
       }
 
       // iterate through all entries
@@ -243,11 +245,13 @@ export class ConditionContext {
       'conditionType' in condition &&
       condition.conditionType === SequentialConditionType
     ) {
-      getAllNestedConditionVariableNames(
-        condition as SequentialConditionProps,
-      ).forEach((varName) => {
-        internalContextVariablesFromConditionVariables.add(`:${varName}`);
-      });
+      (condition as SequentialConditionProps).conditionVariables.forEach(
+        (variable: ConditionVariableProps) => {
+          internalContextVariablesFromConditionVariables.add(
+            `:${variable.varName}`,
+          );
+        },
+      );
     }
 
     // iterate through all properties in ConditionProps

--- a/packages/taco/src/conditions/context/context.ts
+++ b/packages/taco/src/conditions/context/context.ts
@@ -22,6 +22,10 @@ import {
 } from '../const';
 import { getAllNestedConditionVariableNames } from '../schemas/sequential';
 import { SIGNING_CONDITION_OBJECT_CONTEXT_VAR } from '../schemas/signing';
+import {
+  SequentialConditionProps,
+  SequentialConditionType,
+} from '../sequential';
 
 export type CustomContextParam =
   | string
@@ -199,10 +203,28 @@ export class ConditionContext {
       });
     } else if (typeof value === 'object') {
       // dictionary (Record<string, T> - complex object eg. Condition, ConditionVariable, ReturnValueTest etc.)
+
+      // Collect internally-defined variable names from sequential conditions
+      // These are scoped within the condition and should not be required as external context
+      const internalContextVariablesFromConditionVariables = new Set<string>();
+      if (
+        'conditionType' in value &&
+        value.conditionType === SequentialConditionType
+      ) {
+        getAllNestedConditionVariableNames(
+          value as SequentialConditionProps,
+        ).forEach((varName) => {
+          internalContextVariablesFromConditionVariables.add(`:${varName}`);
+        });
+      }
+
+      // iterate through all entries
       for (const [, entry] of Object.entries(value)) {
         const contextVarsForValue = this.findContextParameter(entry);
         contextVarsForValue.forEach((contextVar) => {
-          includedContextVars.add(contextVar);
+          if (!internalContextVariablesFromConditionVariables.has(contextVar)) {
+            includedContextVars.add(contextVar);
+          }
         });
       }
     }
@@ -211,14 +233,22 @@ export class ConditionContext {
   }
 
   private static findContextParameters(condition: ConditionProps) {
-    // Collect internally-defined variable names from sequential conditions
-    // These are scoped within the condition and should not be required as external context
-    const internalVarNames = new Set(
-      getAllNestedConditionVariableNames(condition).map((name) => `:${name}`),
-    );
-
     // find all the context variables we need
     const requestedParameters = new Set<string>();
+
+    // Collect internally-defined variable names from sequential conditions
+    // These are scoped within the condition and should not be required as external context
+    const internalContextVariablesFromConditionVariables = new Set<string>();
+    if (
+      'conditionType' in condition &&
+      condition.conditionType === SequentialConditionType
+    ) {
+      getAllNestedConditionVariableNames(
+        condition as SequentialConditionProps,
+      ).forEach((varName) => {
+        internalContextVariablesFromConditionVariables.add(`:${varName}`);
+      });
+    }
 
     // iterate through all properties in ConditionProps
     const properties = Object.keys(condition) as (keyof typeof condition)[];
@@ -226,7 +256,7 @@ export class ConditionContext {
       this.findContextParameter(condition[prop]).forEach((contextVar) => {
         if (
           !AUTOMATICALLY_INJECTED_CONTEXT_PARAMS.includes(contextVar) &&
-          !internalVarNames.has(contextVar)
+          !internalContextVariablesFromConditionVariables.has(contextVar)
         ) {
           requestedParameters.add(contextVar);
         }

--- a/packages/taco/src/conditions/schemas/sequential.ts
+++ b/packages/taco/src/conditions/schemas/sequential.ts
@@ -9,7 +9,7 @@ import { IfThenElseConditionType } from './if-then-else';
 import { anyConditionSchema } from './utils';
 import { variableOperationsArraySchema } from './variable-operation';
 
-const getAllNestedConditionVariableNames = (
+export const getAllNestedConditionVariableNames = (
   condition: ConditionProps,
 ): string[] => {
   const conditionVariables: string[] = [];

--- a/packages/taco/src/conditions/schemas/sequential.ts
+++ b/packages/taco/src/conditions/schemas/sequential.ts
@@ -71,7 +71,7 @@ export const sequentialConditionSchema: z.ZodSchema = baseConditionSchema
     conditionType: z
       .literal(SequentialConditionType)
       .default(SequentialConditionType),
-    conditionVariables: z.array(conditionVariableSchema).min(2).max(5),
+    conditionVariables: z.array(conditionVariableSchema).min(2).max(10),
   })
   .refine(
     (condition) => maxNestedDepth(2)(condition),

--- a/packages/taco/test/conditions/context.test.ts
+++ b/packages/taco/test/conditions/context.test.ts
@@ -1468,6 +1468,7 @@ describe('sequential condition varName scoping', () => {
     const conditionContext = new ConditionContext(condition);
 
     // :rpcValue should NOT be in requestedContextParameters since it's internally defined
+    expect(conditionContext.requestedContextParameters.size).toBe(0);
     expect(conditionContext.requestedContextParameters).not.toContain(
       ':rpcValue',
     );
@@ -1528,6 +1529,7 @@ describe('sequential condition varName scoping', () => {
     );
 
     // External context params SHOULD be in requestedContextParameters
+    expect(conditionContext.requestedContextParameters.size).toBe(2);
     expect(conditionContext.requestedContextParameters).toContain(
       ':externalThreshold',
     );
@@ -1654,6 +1656,7 @@ describe('sequential condition varName scoping', () => {
     );
 
     // External context param SHOULD be in requestedContextParameters
+    expect(conditionContext.requestedContextParameters.size).toBe(1);
     expect(conditionContext.requestedContextParameters).toContain(
       ':externalParam',
     );
@@ -1719,6 +1722,7 @@ describe('sequential condition varName scoping', () => {
     );
 
     // External context param SHOULD be in requestedContextParameters
+    expect(conditionContext.requestedContextParameters.size).toBe(2);
     expect(conditionContext.requestedContextParameters).toContain(
       ':externalContextVar1',
     );

--- a/packages/taco/test/conditions/context.test.ts
+++ b/packages/taco/test/conditions/context.test.ts
@@ -1438,3 +1438,224 @@ describe('forSigningCohort', () => {
     getSigningCohortConditionsSpy.mockRestore();
   });
 });
+
+describe('sequential condition varName scoping', () => {
+  it('excludes internal varName references from required context parameters', () => {
+    // This sequential condition defines varNames 'rpcValue' and 'timeValue'
+    // and references ':rpcValue' in a subsequent returnValueTest
+    // The ':rpcValue' should NOT be treated as an external context parameter
+    const sequentialCondition = {
+      conditionType: SequentialConditionType,
+      conditionVariables: [
+        {
+          varName: 'rpcValue',
+          condition: testRpcConditionObj,
+        },
+        {
+          varName: 'timeValue',
+          condition: {
+            ...testTimeConditionObj,
+            returnValueTest: {
+              comparator: '>',
+              value: ':rpcValue', // References internal varName
+            },
+          },
+        },
+      ],
+    };
+
+    const condition = ConditionFactory.conditionFromProps(sequentialCondition);
+    const conditionContext = new ConditionContext(condition);
+
+    // :rpcValue should NOT be in requestedContextParameters since it's internally defined
+    expect(conditionContext.requestedContextParameters).not.toContain(
+      ':rpcValue',
+    );
+    expect(conditionContext.requestedContextParameters).not.toContain(
+      ':timeValue',
+    );
+  });
+
+  it('correctly identifies external context params while excluding internal varNames', () => {
+    // This sequential condition has both:
+    // - Internal varNames: 'rpcValue', 'contractValue'
+    // - External context params: ':externalMultiplier', ':externalThreshold'
+    const sequentialCondition = {
+      conditionType: SequentialConditionType,
+      conditionVariables: [
+        {
+          varName: 'rpcValue',
+          condition: testRpcConditionObj,
+        },
+        {
+          varName: 'contractValue',
+          condition: {
+            ...testContractConditionObj,
+            returnValueTest: {
+              comparator: '>',
+              value: ':rpcValue', // Internal reference
+            },
+          },
+        },
+        {
+          varName: 'finalValue',
+          condition: {
+            ...testTimeConditionObj,
+            returnValueTest: {
+              comparator: '>=',
+              value: ':externalThreshold', // External context param
+              operations: [
+                { operation: '*=', value: ':externalMultiplier' }, // External context param
+              ],
+            },
+          },
+        },
+      ],
+    };
+
+    const condition = ConditionFactory.conditionFromProps(sequentialCondition);
+    const conditionContext = new ConditionContext(condition);
+
+    // Internal varNames should NOT be in requestedContextParameters
+    expect(conditionContext.requestedContextParameters).not.toContain(
+      ':rpcValue',
+    );
+    expect(conditionContext.requestedContextParameters).not.toContain(
+      ':contractValue',
+    );
+    expect(conditionContext.requestedContextParameters).not.toContain(
+      ':finalValue',
+    );
+
+    // External context params SHOULD be in requestedContextParameters
+    expect(conditionContext.requestedContextParameters).toContain(
+      ':externalThreshold',
+    );
+    expect(conditionContext.requestedContextParameters).toContain(
+      ':externalMultiplier',
+    );
+  });
+
+  it('handles nested sequential conditions with varName scoping', () => {
+    // Nested sequential conditions should have their varNames properly scoped
+    const nestedSequentialCondition = {
+      conditionType: SequentialConditionType,
+      conditionVariables: [
+        {
+          varName: 'outerRpc',
+          condition: testRpcConditionObj,
+        },
+        {
+          varName: 'nestedSequential',
+          condition: {
+            conditionType: SequentialConditionType,
+            conditionVariables: [
+              {
+                varName: 'innerRpc',
+                condition: testRpcConditionObj,
+              },
+              {
+                varName: 'innerTime',
+                condition: {
+                  ...testTimeConditionObj,
+                  returnValueTest: {
+                    comparator: '>',
+                    value: ':innerRpc', // References inner varName
+                  },
+                },
+              },
+            ],
+          },
+        },
+        {
+          varName: 'outerFinal',
+          condition: {
+            ...testTimeConditionObj,
+            returnValueTest: {
+              comparator: '>=',
+              value: ':outerRpc', // References outer varName
+            },
+          },
+        },
+      ],
+    };
+
+    const condition = ConditionFactory.conditionFromProps(
+      nestedSequentialCondition,
+    );
+    const conditionContext = new ConditionContext(condition);
+
+    // All internal varNames (outer and inner) should NOT be in requestedContextParameters
+    expect(conditionContext.requestedContextParameters).not.toContain(
+      ':outerRpc',
+    );
+    expect(conditionContext.requestedContextParameters).not.toContain(
+      ':nestedSequential',
+    );
+    expect(conditionContext.requestedContextParameters).not.toContain(
+      ':innerRpc',
+    );
+    expect(conditionContext.requestedContextParameters).not.toContain(
+      ':innerTime',
+    );
+    expect(conditionContext.requestedContextParameters).not.toContain(
+      ':outerFinal',
+    );
+
+    // Should have no external context parameters in this case
+    expect(conditionContext.requestedContextParameters.size).toBe(0);
+  });
+
+  it('handles compound conditions containing sequential conditions with varName scoping', () => {
+    const compoundWithSequential = {
+      conditionType: CompoundConditionType,
+      operator: 'or',
+      operands: [
+        {
+          conditionType: SequentialConditionType,
+          conditionVariables: [
+            {
+              varName: 'seqVar1',
+              condition: testRpcConditionObj,
+            },
+            {
+              varName: 'seqVar2',
+              condition: {
+                ...testTimeConditionObj,
+                returnValueTest: {
+                  comparator: '>',
+                  value: ':seqVar1', // Internal reference
+                },
+              },
+            },
+          ],
+        },
+        {
+          ...testContractConditionObj,
+          returnValueTest: {
+            comparator: '>=',
+            value: ':externalParam', // External context param
+          },
+        },
+      ],
+    };
+
+    const condition = ConditionFactory.conditionFromProps(
+      compoundWithSequential,
+    );
+    const conditionContext = new ConditionContext(condition);
+
+    // Internal varNames should NOT be in requestedContextParameters
+    expect(conditionContext.requestedContextParameters).not.toContain(
+      ':seqVar1',
+    );
+    expect(conditionContext.requestedContextParameters).not.toContain(
+      ':seqVar2',
+    );
+
+    // External context param SHOULD be in requestedContextParameters
+    expect(conditionContext.requestedContextParameters).toContain(
+      ':externalParam',
+    );
+  });
+});

--- a/packages/taco/test/conditions/context.test.ts
+++ b/packages/taco/test/conditions/context.test.ts
@@ -1658,4 +1658,72 @@ describe('sequential condition varName scoping', () => {
       ':externalParam',
     );
   });
+  it('handles external context variable within sequential', () => {
+    const compoundWithSequential = {
+      conditionType: CompoundConditionType,
+      operator: 'or',
+      operands: [
+        {
+          conditionType: SequentialConditionType,
+          conditionVariables: [
+            {
+              varName: 'seqVar1',
+              condition: testRpcConditionObj,
+            },
+            {
+              varName: 'seqVar2',
+              condition: {
+                ...testTimeConditionObj,
+                returnValueTest: {
+                  comparator: '>',
+                  value: ':externalContextVar1', // External context param
+                },
+              },
+            },
+            {
+              varName: 'seqVar3',
+              condition: {
+                ...testContractConditionObj,
+                returnValueTest: {
+                  comparator: '<=',
+                  value: ':seqVar1', // Internal reference
+                },
+              },
+            },
+          ],
+        },
+        {
+          ...testContractConditionObj,
+          returnValueTest: {
+            comparator: '>=',
+            value: ':externalContextVar2', // External context param
+          },
+        },
+      ],
+    };
+
+    const condition = ConditionFactory.conditionFromProps(
+      compoundWithSequential,
+    );
+    const conditionContext = new ConditionContext(condition);
+
+    // Internal varNames should NOT be in requestedContextParameters
+    expect(conditionContext.requestedContextParameters).not.toContain(
+      ':seqVar1',
+    );
+    expect(conditionContext.requestedContextParameters).not.toContain(
+      ':seqVar2',
+    );
+    expect(conditionContext.requestedContextParameters).not.toContain(
+      ':seqVar3',
+    );
+
+    // External context param SHOULD be in requestedContextParameters
+    expect(conditionContext.requestedContextParameters).toContain(
+      ':externalContextVar1',
+    );
+    expect(conditionContext.requestedContextParameters).toContain(
+      ':externalContextVar2',
+    );
+  });
 });

--- a/packages/taco/test/conditions/sequential.test.ts
+++ b/packages/taco/test/conditions/sequential.test.ts
@@ -112,7 +112,7 @@ describe('validation', () => {
   });
 
   it('rejects > max number of condition variables', () => {
-    const tooManyConditionVariables = new Array(6);
+    const tooManyConditionVariables = new Array(11);
     for (let i = 0; i < tooManyConditionVariables.length; i++) {
       tooManyConditionVariables[i] = {
         varName: `var${i}`,
@@ -127,7 +127,7 @@ describe('validation', () => {
     expect(result.data).toBeUndefined();
     expect(result.error?.format()).toMatchObject({
       conditionVariables: {
-        _errors: ['Array must contain at most 5 element(s)'],
+        _errors: ['Array must contain at most 10 element(s)'],
       },
     });
   });


### PR DESCRIPTION
## Summary

Fixes a bug where `findContextParameters()` incorrectly treated internal sequential condition `varName` references as external context parameters.

## Problem

When a sequential condition defines `varName: 'amountValue'` and later references `:amountValue` in a `returnValueTest.value`, the SDK was incorrectly treating `:amountValue` as an external parameter that must be provided by the caller.

## Solution

Modified `findContextParameters()` to:
1. Collect all `varName` declarations from sequential conditions using the existing `getAllNestedConditionVariableNames()` helper
2. Convert them to context param format (`:varName`)
3. Exclude these internal variables from the required external parameters

## Changes

- Export `getAllNestedConditionVariableNames` from `sequential.ts`
- Modify `findContextParameters()` to collect and exclude internal varNames
- Add comprehensive tests for sequential condition varName scoping
- Update max number of allowed conditions within `SequentialCondition` to 10 to match https://github.com/nucypher/nucypher/pull/3662

## Testing

- Added 4 new tests covering:
  - Basic internal varName exclusion
  - Mixed internal/external context params
  - Nested sequential conditions
  - Compound conditions containing sequential conditions
- All existing tests pass