### PR TITLE
fix(taco): prevent varName from colliding with context parameter names

### DIFF
--- a/packages/taco/src/conditions/const.ts
+++ b/packages/taco/src/conditions/const.ts
@@ -16,3 +16,50 @@ export const USER_ADDRESS_PARAMS = [
   // Ordering matters, this should always be last
   USER_ADDRESS_PARAM_DEFAULT,
 ];
+
+/**
+ * Checks if a value is a context parameter (entire string matches pattern).
+ */
+export const isContextParameter = (param: unknown): boolean => {
+  return !!String(param).match(CONTEXT_PARAM_FULL_MATCH_REGEXP);
+};
+
+/**
+ * Recursively finds all context parameters (`:paramName`) in a value.
+ * Handles strings, arrays, and objects.
+ */
+export const findAllContextParams = (value: unknown): Set<string> => {
+  const contextParams = new Set<string>();
+
+  if (!value) {
+    return contextParams;
+  }
+
+  if (typeof value === 'string') {
+    if (isContextParameter(value)) {
+      // entire string is context parameter
+      contextParams.add(String(value));
+    } else {
+      // context var could be substring; find all matches
+      const matches = value.match(
+        // RegExp with 'g' is stateful, so new instance needed every time
+        new RegExp(CONTEXT_PARAM_REGEXP.source, 'g'),
+      );
+      if (matches) {
+        for (const match of matches) {
+          contextParams.add(match);
+        }
+      }
+    }
+  } else if (Array.isArray(value)) {
+    value.forEach((item) => {
+      findAllContextParams(item).forEach((param) => contextParams.add(param));
+    });
+  } else if (typeof value === 'object') {
+    for (const [, entry] of Object.entries(value)) {
+      findAllContextParams(entry).forEach((param) => contextParams.add(param));
+    }
+  }
+
+  return contextParams;
+};

--- a/packages/taco/src/conditions/context/context.ts
+++ b/packages/taco/src/conditions/context/context.ts
@@ -15,9 +15,9 @@ import { toJSON } from '../../utils';
 import { Condition, ConditionProps } from '../condition';
 import { ConditionExpression } from '../condition-expr';
 import {
-  CONTEXT_PARAM_FULL_MATCH_REGEXP,
   CONTEXT_PARAM_PREFIX,
-  CONTEXT_PARAM_REGEXP,
+  findAllContextParams,
+  isContextParameter,
   USER_ADDRESS_PARAMS,
 } from '../const';
 import { getAllNestedConditionVariableNames } from '../schemas/sequential';
@@ -144,7 +144,7 @@ export class ConditionContext {
   }
 
   private validateCustomContextParameter(customParam: string): void {
-    if (!ConditionContext.isContextParameter(customParam)) {
+    if (!isContextParameter(customParam)) {
       throw new Error(ERR_INVALID_CUSTOM_PARAM(customParam));
     }
 
@@ -161,55 +161,6 @@ export class ConditionContext {
     }
   }
 
-  private static isContextParameter(param: unknown): boolean {
-    return !!String(param).match(CONTEXT_PARAM_FULL_MATCH_REGEXP);
-  }
-
-  private static findContextParameter(value: unknown): Set<string> {
-    const includedContextVars = new Set<string>();
-
-    // value not set
-    if (!value) {
-      return includedContextVars;
-    }
-
-    if (typeof value === 'string') {
-      if (this.isContextParameter(value)) {
-        // entire string is context parameter
-        includedContextVars.add(String(value));
-      } else {
-        // context var could be substring; find all matches
-        const contextVarMatches = value.match(
-          // RegExp with 'g' is stateful, so new instance needed every time
-          new RegExp(CONTEXT_PARAM_REGEXP.source, 'g'),
-        );
-        if (contextVarMatches) {
-          for (const match of contextVarMatches) {
-            includedContextVars.add(match);
-          }
-        }
-      }
-    } else if (Array.isArray(value)) {
-      // array
-      value.forEach((subValue) => {
-        const contextVarsForValue = this.findContextParameter(subValue);
-        contextVarsForValue.forEach((contextVar) => {
-          includedContextVars.add(contextVar);
-        });
-      });
-    } else if (typeof value === 'object') {
-      // dictionary (Record<string, T> - complex object eg. Condition, ConditionVariable, ReturnValueTest etc.)
-      for (const [, entry] of Object.entries(value)) {
-        const contextVarsForValue = this.findContextParameter(entry);
-        contextVarsForValue.forEach((contextVar) => {
-          includedContextVars.add(contextVar);
-        });
-      }
-    }
-
-    return includedContextVars;
-  }
-
   private static findContextParameters(condition: ConditionProps) {
     // Collect internally-defined variable names from sequential conditions
     // These are scoped within the condition and should not be required as external context
@@ -223,7 +174,7 @@ export class ConditionContext {
     // iterate through all properties in ConditionProps
     const properties = Object.keys(condition) as (keyof typeof condition)[];
     properties.forEach((prop) => {
-      this.findContextParameter(condition[prop]).forEach((contextVar) => {
+      findAllContextParams(condition[prop]).forEach((contextVar) => {
         if (
           !AUTOMATICALLY_INJECTED_CONTEXT_PARAMS.includes(contextVar) &&
           !internalVarNames.has(contextVar)

--- a/packages/taco/src/conditions/schemas/sequential.ts
+++ b/packages/taco/src/conditions/schemas/sequential.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 
 import { ConditionProps } from '../condition';
+import { CONTEXT_PARAM_REGEXP } from '../const';
 import { maxNestedDepth } from '../multi-condition';
 
 import { baseConditionSchema, plainStringSchema } from './common';
@@ -48,6 +49,55 @@ const noDuplicateVarNames = (condition: ConditionProps): boolean => {
   return duplicates.length === 0;
 };
 
+/**
+ * Recursively finds all context parameters (`:paramName`) in a condition tree.
+ */
+const findAllContextParams = (value: unknown): Set<string> => {
+  const contextParams = new Set<string>();
+
+  if (!value) {
+    return contextParams;
+  }
+
+  if (typeof value === 'string') {
+    // Find all context param matches in the string
+    const matches = value.match(new RegExp(CONTEXT_PARAM_REGEXP.source, 'g'));
+    if (matches) {
+      matches.forEach((match) => contextParams.add(match));
+    }
+  } else if (Array.isArray(value)) {
+    value.forEach((item) => {
+      findAllContextParams(item).forEach((param) => contextParams.add(param));
+    });
+  } else if (typeof value === 'object') {
+    Object.values(value).forEach((entry) => {
+      findAllContextParams(entry).forEach((param) => contextParams.add(param));
+    });
+  }
+
+  return contextParams;
+};
+
+/**
+ * Validates that no varName collides with an external context parameter.
+ * If a varName 'foo' is defined, ':foo' cannot also be used as a context param.
+ */
+const noVarNameContextParamCollisions = (
+  condition: ConditionProps,
+): boolean => {
+  const allVarNames = getAllNestedConditionVariableNames(condition);
+  const allContextParams = findAllContextParams(condition);
+
+  // Check if any varName (with : prefix) appears in context params
+  for (const varName of allVarNames) {
+    if (allContextParams.has(`:${varName}`)) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
 export const SequentialConditionType = 'sequential';
 
 export const conditionVariableSchema: z.ZodSchema = z.lazy(() =>
@@ -86,6 +136,16 @@ export const sequentialConditionSchema: z.ZodSchema = baseConditionSchema
     },
     {
       message: 'Duplicate variable names are not allowed',
+      path: ['conditionVariables'],
+    },
+  )
+  .refine(
+    (condition) => {
+      return noVarNameContextParamCollisions(condition);
+    },
+    {
+      message:
+        'Variable name cannot be the same as a context parameter name used in the condition',
       path: ['conditionVariables'],
     },
   );

--- a/packages/taco/src/conditions/schemas/sequential.ts
+++ b/packages/taco/src/conditions/schemas/sequential.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
 import { ConditionProps } from '../condition';
-import { CONTEXT_PARAM_REGEXP } from '../const';
+import { findAllContextParams } from '../const';
 import { maxNestedDepth } from '../multi-condition';
 
 import { baseConditionSchema, plainStringSchema } from './common';
@@ -47,35 +47,6 @@ const noDuplicateVarNames = (condition: ConditionProps): boolean => {
     (item, index) => allVarNames.indexOf(item) !== index,
   );
   return duplicates.length === 0;
-};
-
-/**
- * Recursively finds all context parameters (`:paramName`) in a condition tree.
- */
-const findAllContextParams = (value: unknown): Set<string> => {
-  const contextParams = new Set<string>();
-
-  if (!value) {
-    return contextParams;
-  }
-
-  if (typeof value === 'string') {
-    // Find all context param matches in the string
-    const matches = value.match(new RegExp(CONTEXT_PARAM_REGEXP.source, 'g'));
-    if (matches) {
-      matches.forEach((match) => contextParams.add(match));
-    }
-  } else if (Array.isArray(value)) {
-    value.forEach((item) => {
-      findAllContextParams(item).forEach((param) => contextParams.add(param));
-    });
-  } else if (typeof value === 'object') {
-    Object.values(value).forEach((entry) => {
-      findAllContextParams(entry).forEach((param) => contextParams.add(param));
-    });
-  }
-
-  return contextParams;
 };
 
 /**

--- a/packages/taco/test/conditions/context.test.ts
+++ b/packages/taco/test/conditions/context.test.ts
@@ -1440,65 +1440,27 @@ describe('forSigningCohort', () => {
 });
 
 describe('sequential condition varName scoping', () => {
-  it('excludes internal varName references from required context parameters', () => {
-    // This sequential condition defines varNames 'rpcValue' and 'timeValue'
-    // and references ':rpcValue' in a subsequent returnValueTest
-    // The ':rpcValue' should NOT be treated as an external context parameter
+  // Note: Tests that use varName references (e.g., ':rpcValue' referencing varName: 'rpcValue')
+  // have been removed because schema validation now prevents varNames from having the same
+  // name as context parameters. This is intentional to avoid ambiguity between internal
+  // varName references and external context parameters.
+  // See: sequential.test.ts 'varName and context param collision' tests for validation behavior.
+
+  it('correctly identifies external context params in sequential conditions', () => {
+    // Sequential condition with only external context params (no varName collisions)
     const sequentialCondition = {
       conditionType: SequentialConditionType,
       conditionVariables: [
         {
-          varName: 'rpcValue',
+          varName: 'rpcResult',
           condition: testRpcConditionObj,
         },
         {
-          varName: 'timeValue',
-          condition: {
-            ...testTimeConditionObj,
-            returnValueTest: {
-              comparator: '>',
-              value: ':rpcValue', // References internal varName
-            },
-          },
-        },
-      ],
-    };
-
-    const condition = ConditionFactory.conditionFromProps(sequentialCondition);
-    const conditionContext = new ConditionContext(condition);
-
-    // :rpcValue should NOT be in requestedContextParameters since it's internally defined
-    expect(conditionContext.requestedContextParameters).not.toContain(
-      ':rpcValue',
-    );
-    expect(conditionContext.requestedContextParameters).not.toContain(
-      ':timeValue',
-    );
-  });
-
-  it('correctly identifies external context params while excluding internal varNames', () => {
-    // This sequential condition has both:
-    // - Internal varNames: 'rpcValue', 'contractValue'
-    // - External context params: ':externalMultiplier', ':externalThreshold'
-    const sequentialCondition = {
-      conditionType: SequentialConditionType,
-      conditionVariables: [
-        {
-          varName: 'rpcValue',
-          condition: testRpcConditionObj,
+          varName: 'contractResult',
+          condition: testContractConditionObj,
         },
         {
-          varName: 'contractValue',
-          condition: {
-            ...testContractConditionObj,
-            returnValueTest: {
-              comparator: '>',
-              value: ':rpcValue', // Internal reference
-            },
-          },
-        },
-        {
-          varName: 'finalValue',
+          varName: 'finalResult',
           condition: {
             ...testTimeConditionObj,
             returnValueTest: {
@@ -1516,17 +1478,6 @@ describe('sequential condition varName scoping', () => {
     const condition = ConditionFactory.conditionFromProps(sequentialCondition);
     const conditionContext = new ConditionContext(condition);
 
-    // Internal varNames should NOT be in requestedContextParameters
-    expect(conditionContext.requestedContextParameters).not.toContain(
-      ':rpcValue',
-    );
-    expect(conditionContext.requestedContextParameters).not.toContain(
-      ':contractValue',
-    );
-    expect(conditionContext.requestedContextParameters).not.toContain(
-      ':finalValue',
-    );
-
     // External context params SHOULD be in requestedContextParameters
     expect(conditionContext.requestedContextParameters).toContain(
       ':externalThreshold',
@@ -1536,13 +1487,12 @@ describe('sequential condition varName scoping', () => {
     );
   });
 
-  it('handles nested sequential conditions with varName scoping', () => {
-    // Nested sequential conditions should have their varNames properly scoped
+  it('handles nested sequential conditions with external context params', () => {
     const nestedSequentialCondition = {
       conditionType: SequentialConditionType,
       conditionVariables: [
         {
-          varName: 'outerRpc',
+          varName: 'outerResult',
           condition: testRpcConditionObj,
         },
         {
@@ -1551,7 +1501,7 @@ describe('sequential condition varName scoping', () => {
             conditionType: SequentialConditionType,
             conditionVariables: [
               {
-                varName: 'innerRpc',
+                varName: 'innerResult',
                 condition: testRpcConditionObj,
               },
               {
@@ -1560,7 +1510,7 @@ describe('sequential condition varName scoping', () => {
                   ...testTimeConditionObj,
                   returnValueTest: {
                     comparator: '>',
-                    value: ':innerRpc', // References inner varName
+                    value: ':nestedExternalParam', // External context param
                   },
                 },
               },
@@ -1573,7 +1523,7 @@ describe('sequential condition varName scoping', () => {
             ...testTimeConditionObj,
             returnValueTest: {
               comparator: '>=',
-              value: ':outerRpc', // References outer varName
+              value: ':outerExternalParam', // External context param
             },
           },
         },
@@ -1585,28 +1535,17 @@ describe('sequential condition varName scoping', () => {
     );
     const conditionContext = new ConditionContext(condition);
 
-    // All internal varNames (outer and inner) should NOT be in requestedContextParameters
-    expect(conditionContext.requestedContextParameters).not.toContain(
-      ':outerRpc',
+    // External context params SHOULD be in requestedContextParameters
+    expect(conditionContext.requestedContextParameters).toContain(
+      ':nestedExternalParam',
     );
-    expect(conditionContext.requestedContextParameters).not.toContain(
-      ':nestedSequential',
+    expect(conditionContext.requestedContextParameters).toContain(
+      ':outerExternalParam',
     );
-    expect(conditionContext.requestedContextParameters).not.toContain(
-      ':innerRpc',
-    );
-    expect(conditionContext.requestedContextParameters).not.toContain(
-      ':innerTime',
-    );
-    expect(conditionContext.requestedContextParameters).not.toContain(
-      ':outerFinal',
-    );
-
-    // Should have no external context parameters in this case
-    expect(conditionContext.requestedContextParameters.size).toBe(0);
+    expect(conditionContext.requestedContextParameters.size).toBe(2);
   });
 
-  it('handles compound conditions containing sequential conditions with varName scoping', () => {
+  it('handles compound conditions containing sequential conditions with external context params', () => {
     const compoundWithSequential = {
       conditionType: CompoundConditionType,
       operator: 'or',
@@ -1615,16 +1554,16 @@ describe('sequential condition varName scoping', () => {
           conditionType: SequentialConditionType,
           conditionVariables: [
             {
-              varName: 'seqVar1',
+              varName: 'seqResult1',
               condition: testRpcConditionObj,
             },
             {
-              varName: 'seqVar2',
+              varName: 'seqResult2',
               condition: {
                 ...testTimeConditionObj,
                 returnValueTest: {
                   comparator: '>',
-                  value: ':seqVar1', // Internal reference
+                  value: ':seqExternalParam', // External context param
                 },
               },
             },
@@ -1634,7 +1573,7 @@ describe('sequential condition varName scoping', () => {
           ...testContractConditionObj,
           returnValueTest: {
             comparator: '>=',
-            value: ':externalParam', // External context param
+            value: ':compoundExternalParam', // External context param
           },
         },
       ],
@@ -1645,17 +1584,12 @@ describe('sequential condition varName scoping', () => {
     );
     const conditionContext = new ConditionContext(condition);
 
-    // Internal varNames should NOT be in requestedContextParameters
-    expect(conditionContext.requestedContextParameters).not.toContain(
-      ':seqVar1',
-    );
-    expect(conditionContext.requestedContextParameters).not.toContain(
-      ':seqVar2',
-    );
-
-    // External context param SHOULD be in requestedContextParameters
+    // External context params SHOULD be in requestedContextParameters
     expect(conditionContext.requestedContextParameters).toContain(
-      ':externalParam',
+      ':seqExternalParam',
+    );
+    expect(conditionContext.requestedContextParameters).toContain(
+      ':compoundExternalParam',
     );
   });
 });

--- a/packages/taco/test/conditions/sequential.test.ts
+++ b/packages/taco/test/conditions/sequential.test.ts
@@ -520,4 +520,228 @@ describe('validation', () => {
     expect(result.error).toBeUndefined();
     expect(result.data).toEqual(conditionObj);
   });
+
+  describe('varName and context param collision', () => {
+    it('rejects when varName collides with context param in returnValueTest', () => {
+      const conditionObj = {
+        conditionType: SequentialConditionType,
+        conditionVariables: [
+          {
+            varName: 'myValue',
+            condition: testRpcConditionObj,
+          },
+          {
+            varName: 'result',
+            condition: {
+              ...testTimeConditionObj,
+              returnValueTest: {
+                comparator: '>',
+                value: ':myValue', // This collides with varName 'myValue'
+              },
+            },
+          },
+        ],
+      };
+      const result = SequentialCondition.validate(
+        sequentialConditionSchema,
+        conditionObj,
+      );
+      expect(result.error).toBeDefined();
+      expect(result.data).toBeUndefined();
+      expect(result.error?.format()).toMatchObject({
+        conditionVariables: {
+          _errors: [
+            'Variable name cannot be the same as a context parameter name used in the condition',
+          ],
+        },
+      });
+    });
+
+    it('rejects when varName collides with context param in operations', () => {
+      const conditionObj = {
+        conditionType: SequentialConditionType,
+        conditionVariables: [
+          {
+            varName: 'multiplier',
+            condition: testRpcConditionObj,
+          },
+          {
+            varName: 'result',
+            condition: {
+              ...testTimeConditionObj,
+              returnValueTest: {
+                comparator: '>',
+                value: 100,
+                operations: [
+                  { operation: '*=', value: ':multiplier' }, // Collides with varName
+                ],
+              },
+            },
+          },
+        ],
+      };
+      const result = SequentialCondition.validate(
+        sequentialConditionSchema,
+        conditionObj,
+      );
+      expect(result.error).toBeDefined();
+      expect(result.data).toBeUndefined();
+      expect(result.error?.format()).toMatchObject({
+        conditionVariables: {
+          _errors: [
+            'Variable name cannot be the same as a context parameter name used in the condition',
+          ],
+        },
+      });
+    });
+
+    it('rejects when nested sequential varName collides with context param in outer condition', () => {
+      const conditionObj = {
+        conditionType: SequentialConditionType,
+        conditionVariables: [
+          {
+            varName: 'outer',
+            condition: {
+              ...testRpcConditionObj,
+              returnValueTest: {
+                comparator: '>',
+                value: ':innerVar', // References a varName defined in nested sequential
+              },
+            },
+          },
+          {
+            varName: 'nested',
+            condition: {
+              conditionType: SequentialConditionType,
+              conditionVariables: [
+                {
+                  varName: 'innerVar', // This varName collides with :innerVar above
+                  condition: testRpcConditionObj,
+                },
+                {
+                  varName: 'innerResult',
+                  condition: testTimeConditionObj,
+                },
+              ],
+            },
+          },
+        ],
+      };
+      const result = SequentialCondition.validate(
+        sequentialConditionSchema,
+        conditionObj,
+      );
+      expect(result.error).toBeDefined();
+      expect(result.data).toBeUndefined();
+      expect(result.error?.format()).toMatchObject({
+        conditionVariables: {
+          _errors: [
+            'Variable name cannot be the same as a context parameter name used in the condition',
+          ],
+        },
+      });
+    });
+
+    it('rejects when varName collides with context param in compound condition', () => {
+      const conditionObj = {
+        conditionType: SequentialConditionType,
+        conditionVariables: [
+          {
+            varName: 'threshold',
+            condition: testRpcConditionObj,
+          },
+          {
+            varName: 'compound',
+            condition: {
+              conditionType: CompoundConditionType,
+              operator: 'and',
+              operands: [
+                {
+                  ...testTimeConditionObj,
+                  returnValueTest: {
+                    comparator: '>',
+                    value: ':threshold', // Collides with varName
+                  },
+                },
+                testRpcConditionObj,
+              ],
+            },
+          },
+        ],
+      };
+      const result = SequentialCondition.validate(
+        sequentialConditionSchema,
+        conditionObj,
+      );
+      expect(result.error).toBeDefined();
+      expect(result.data).toBeUndefined();
+      expect(result.error?.format()).toMatchObject({
+        conditionVariables: {
+          _errors: [
+            'Variable name cannot be the same as a context parameter name used in the condition',
+          ],
+        },
+      });
+    });
+
+    it('allows different names for varName and context params', () => {
+      const conditionObj = {
+        conditionType: SequentialConditionType,
+        conditionVariables: [
+          {
+            varName: 'rpcResult',
+            condition: testRpcConditionObj,
+          },
+          {
+            varName: 'timeResult',
+            condition: {
+              ...testTimeConditionObj,
+              returnValueTest: {
+                comparator: '>',
+                value: ':externalThreshold', // Different name, no collision
+              },
+            },
+          },
+        ],
+      };
+      const result = SequentialCondition.validate(
+        sequentialConditionSchema,
+        conditionObj,
+      );
+      expect(result.error).toBeUndefined();
+      expect(result.data).toBeDefined();
+    });
+
+    it('rejects when varName collides with context param as substring', () => {
+      const conditionObj = {
+        conditionType: SequentialConditionType,
+        conditionVariables: [
+          {
+            varName: 'amount',
+            condition: testRpcConditionObj,
+          },
+          {
+            varName: 'result',
+            condition: {
+              ...testJsonApiConditionObj,
+              query: '$.data[:amount].value', // :amount appears as substring
+            },
+          },
+        ],
+      };
+      const result = SequentialCondition.validate(
+        sequentialConditionSchema,
+        conditionObj,
+      );
+      expect(result.error).toBeDefined();
+      expect(result.data).toBeUndefined();
+      expect(result.error?.format()).toMatchObject({
+        conditionVariables: {
+          _errors: [
+            'Variable name cannot be the same as a context parameter name used in the condition',
+          ],
+        },
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Fixes a bug where an external context parameter with the same name as an internal `varName` in a sequential condition would be incorrectly excluded from `requestedContextParameters`.

## Problem

When a `varName` in a sequential condition has the same name as a context parameter, the previous fix would incorrectly exclude that external context param from `requestedContextParameters`, effectively making it invisible to the user.

## Solution

Add schema-level validation to reject sequential conditions where a `varName` has the same name as a context parameter used in the condition. This prevents the ambiguous situation entirely.

**Rule:** If you define `varName: 'foo'`, you cannot also use `:foo` as a context parameter - one must be renamed.

## Changes

- Add `findAllContextParams()` helper to recursively find all context parameters in a condition tree
- Add `noVarNameContextParamCollisions()` validation function  
- Add `.refine()` check to `sequentialConditionSchema` - https://zod.dev/api?id=refinements
- Add tests for collision rejection scenarios (returnValueTest, operations, nested sequential, compound conditions)
- Update `context.test.ts` to use non-colliding names

## BREAKING CHANGE

Sequential conditions with varNames that match context parameter names will now be rejected at schema validation time with the error:
> "Variable name cannot be the same as a context parameter name used in the condition"