### PR TITLE
feat(taco): increase condition limits and add exponent operator

### DIFF
--- a/packages/taco/integration-test/condition-lingo.test.ts
+++ b/packages/taco/integration-test/condition-lingo.test.ts
@@ -65,8 +65,9 @@ describe.skipIf(!process.env.RUNNING_IN_CI)(
   () => {
     test('validate condition lingo with lynx node to confirm consistency', async () => {
       // Note: there are limits to conditions
-      // - max 5 operands in a multi-condition (compound, sequential)
-      // - max 2 nested levels of multi-conditions (compound, sequential, if-then-else)
+      // - max 5 operands in a compound condition
+      // - max 20 condition variables in a sequential condition
+      // - max 4 nested levels of multi-conditions (compound, sequential, if-then-else)
       const overallCondition = new SequentialCondition({
         conditionVariables: [
           {
@@ -143,11 +144,9 @@ describe.skipIf(!process.env.RUNNING_IN_CI)(
           '975fda96fa12226a378f52a423e2d12d4fed717162ec7e5838169ed57e3357f2410dce2ce1b6bce3bb46ee97d90e542d9895c7d5b0224da05209eaaf0e484acd',
       };
 
-      // Value used for chunkSize is to ensure:
-      // 1. we don't exceed the max 5 operands in a multi-condition
-      // 2. we adhere to the fact that "and" compound conditions must have at least 2 operands
-      // 3. SUPPORTED_ECDSA_CURVES.length is currently 6, so we can split it into chunks of 3
-      const chunkSize = 3;
+      // chunkSize ensures we don't exceed max 5 operands in a compound condition
+      // and that "and" compound conditions have at least 2 operands
+      const chunkSize = 5;
       for (let i = 0; i < SUPPORTED_ECDSA_CURVES.length; i += chunkSize) {
         const chunk = SUPPORTED_ECDSA_CURVES.slice(i, i + chunkSize);
         const operands: ECDSAConditionProps[] = chunk.map((curve) => ({

--- a/packages/taco/integration-test/condition-lingo.test.ts
+++ b/packages/taco/integration-test/condition-lingo.test.ts
@@ -144,9 +144,11 @@ describe.skipIf(!process.env.RUNNING_IN_CI)(
           '975fda96fa12226a378f52a423e2d12d4fed717162ec7e5838169ed57e3357f2410dce2ce1b6bce3bb46ee97d90e542d9895c7d5b0224da05209eaaf0e484acd',
       };
 
-      // chunkSize ensures we don't exceed max 5 operands in a compound condition
-      // and that "and" compound conditions have at least 2 operands
-      const chunkSize = 5;
+      // Value used for chunkSize is to ensure:
+      // 1. we don't exceed the max 5 operands in a compound condition
+      // 2. we adhere to the fact that "and" compound conditions must have at least 2 operands
+      // 3. SUPPORTED_ECDSA_CURVES.length is currently 6, so we can split it into chunks of 3
+      const chunkSize = 3;
       for (let i = 0; i < SUPPORTED_ECDSA_CURVES.length; i += chunkSize) {
         const chunk = SUPPORTED_ECDSA_CURVES.slice(i, i + chunkSize);
         const operands: ECDSAConditionProps[] = chunk.map((curve) => ({

--- a/packages/taco/schema-docs/condition-schemas.md
+++ b/packages/taco/schema-docs/condition-schemas.md
@@ -306,10 +306,10 @@ _(\*) Required._
 
 _Object containing the following properties:_
 
-| Property                      | Type                                                                                | Default        |
-| :---------------------------- | :---------------------------------------------------------------------------------- | :------------- |
-| `conditionType`               | `'sequential'`                                                                      | `'sequential'` |
-| **`conditionVariables`** (\*) | _Array of at least 2  and  at most 5 [ConditionVariable](#conditionvariable) items_ |                |
+| Property                      | Type                                                                                 | Default        |
+| :---------------------------- | :----------------------------------------------------------------------------------- | :------------- |
+| `conditionType`               | `'sequential'`                                                                       | `'sequential'` |
+| **`conditionVariables`** (\*) | _Array of at least 2  and  at most 20 [ConditionVariable](#conditionvariable) items_ |                |
 
 _(\*) Required._
 
@@ -383,10 +383,10 @@ An operation that can be performed on an obtained result.
 
 _Object containing the following properties:_
 
-| Property             | Type                                                                                                                                                                                                     |
-| :------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **`operation`** (\*) | `'+=' \| '-=' \| '*=' \| '/=' \| '%=' \| 'index' \| 'round' \| 'abs' \| 'avg' \| 'ceil' \| 'ethToWei' \| 'floor' \| 'len' \| 'max' \| 'min' \| 'sum' \| 'weiToEth' \| 'bool' \| 'float' \| 'int' \| ...` |
-| `value`              | [ParamOrContextParam](#paramorcontextparam)                                                                                                                                                              |
+| Property             | Type                                                                                                                                                                                                                  |
+| :------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`operation`** (\*) | `'+=' \| '-=' \| '*=' \| '/=' \| '%=' \| 'toTokenBaseUnits' \| 'index' \| 'round' \| 'abs' \| 'avg' \| 'ceil' \| 'ethToWei' \| 'floor' \| 'len' \| 'max' \| 'min' \| 'sum' \| 'weiToEth' \| 'bool' \| 'float' \| ...` |
+| `value`              | [ParamOrContextParam](#paramorcontextparam)                                                                                                                                                                           |
 
 _(\*) Required._
 

--- a/packages/taco/src/conditions/schemas/compound.ts
+++ b/packages/taco/src/conditions/schemas/compound.ts
@@ -37,11 +37,11 @@ export const compoundConditionSchema: z.ZodSchema = z.lazy(() =>
       }),
     )
     .refine(
-      (condition) => maxNestedDepth(2)(condition),
+      (condition) => maxNestedDepth(4)(condition),
       {
-        message: 'Exceeded max nested depth of 2 for multi-condition type',
+        message: 'Exceeded max nested depth of 4 for multi-condition type',
         path: ['operands'],
-      }, // Max nested depth of 2
+      }, // Max nested depth of 4
     ),
 );
 

--- a/packages/taco/src/conditions/schemas/if-then-else.ts
+++ b/packages/taco/src/conditions/schemas/if-then-else.ts
@@ -19,32 +19,32 @@ export const ifThenElseConditionSchema: z.ZodSchema = z.lazy(() =>
     })
     .refine(
       // already at 2nd level since checking member condition
-      (condition) => maxNestedDepth(2)(condition.ifCondition, 2),
+      (condition) => maxNestedDepth(4)(condition.ifCondition, 2),
       {
-        message: 'Exceeded max nested depth of 2 for multi-condition type',
+        message: 'Exceeded max nested depth of 4 for multi-condition type',
         path: ['ifCondition'],
-      }, // Max nested depth of 2
+      }, // Max nested depth of 4
     )
     .refine(
       // already at 2nd level since checking member condition
-      (condition) => maxNestedDepth(2)(condition.thenCondition, 2),
+      (condition) => maxNestedDepth(4)(condition.thenCondition, 2),
       {
-        message: 'Exceeded max nested depth of 2 for multi-condition type',
+        message: 'Exceeded max nested depth of 4 for multi-condition type',
         path: ['thenCondition'],
-      }, // Max nested depth of 2
+      }, // Max nested depth of 4
     )
     .refine(
       (condition) => {
         if (typeof condition.elseCondition !== 'boolean') {
           // already at 2nd level since checking member condition
-          return maxNestedDepth(2)(condition.elseCondition, 2);
+          return maxNestedDepth(4)(condition.elseCondition, 2);
         }
         return true;
       },
       {
-        message: 'Exceeded max nested depth of 2 for multi-condition type',
+        message: 'Exceeded max nested depth of 4 for multi-condition type',
         path: ['elseCondition'],
-      }, // Max nested depth of 2
+      }, // Max nested depth of 4
     ),
 );
 

--- a/packages/taco/src/conditions/schemas/sequential.ts
+++ b/packages/taco/src/conditions/schemas/sequential.ts
@@ -71,7 +71,7 @@ export const sequentialConditionSchema: z.ZodSchema = baseConditionSchema
     conditionType: z
       .literal(SequentialConditionType)
       .default(SequentialConditionType),
-    conditionVariables: z.array(conditionVariableSchema).min(2).max(10),
+    conditionVariables: z.array(conditionVariableSchema).min(2).max(20),
   })
   .refine(
     (condition) => maxNestedDepth(4)(condition),

--- a/packages/taco/src/conditions/schemas/sequential.ts
+++ b/packages/taco/src/conditions/schemas/sequential.ts
@@ -74,11 +74,11 @@ export const sequentialConditionSchema: z.ZodSchema = baseConditionSchema
     conditionVariables: z.array(conditionVariableSchema).min(2).max(10),
   })
   .refine(
-    (condition) => maxNestedDepth(2)(condition),
+    (condition) => maxNestedDepth(4)(condition),
     {
-      message: 'Exceeded max nested depth of 2 for multi-condition type',
+      message: 'Exceeded max nested depth of 4 for multi-condition type',
       path: ['conditionVariables'],
-    }, // Max nested depth of 2
+    }, // Max nested depth of 4
   )
   .refine(
     (condition) => {

--- a/packages/taco/src/conditions/schemas/variable-operation.ts
+++ b/packages/taco/src/conditions/schemas/variable-operation.ts
@@ -8,7 +8,7 @@ export const OPERATOR_FUNCTIONS = [
   '*=',
   '/=',
   '%=',
-  'pow',
+  '*pow=',
   'index',
   'round',
   // operations that don't require 2nd value

--- a/packages/taco/src/conditions/schemas/variable-operation.ts
+++ b/packages/taco/src/conditions/schemas/variable-operation.ts
@@ -8,6 +8,7 @@ export const OPERATOR_FUNCTIONS = [
   '*=',
   '/=',
   '%=',
+  '**=',
   'index',
   'round',
   // operations that don't require 2nd value

--- a/packages/taco/src/conditions/schemas/variable-operation.ts
+++ b/packages/taco/src/conditions/schemas/variable-operation.ts
@@ -8,7 +8,7 @@ export const OPERATOR_FUNCTIONS = [
   '*=',
   '/=',
   '%=',
-  '**=',
+  'pow',
   'index',
   'round',
   // operations that don't require 2nd value

--- a/packages/taco/src/conditions/schemas/variable-operation.ts
+++ b/packages/taco/src/conditions/schemas/variable-operation.ts
@@ -8,7 +8,7 @@ export const OPERATOR_FUNCTIONS = [
   '*=',
   '/=',
   '%=',
-  '*pow=',
+  'toTokenBaseUnits',
   'index',
   'round',
   // operations that don't require 2nd value

--- a/packages/taco/test/conditions/compound-condition.test.ts
+++ b/packages/taco/test/conditions/compound-condition.test.ts
@@ -204,11 +204,11 @@ describe('validation', () => {
   });
 
   it('limits max depth of nested compound condition', () => {
+    // Create 5 levels of nesting to exceed max depth of 4
     const result = CompoundCondition.validate(compoundConditionSchema, {
       operator: 'or',
       operands: [
         testRpcConditionObj,
-        testContractConditionObj,
         {
           conditionType: CompoundConditionType,
           operator: 'and',
@@ -217,7 +217,21 @@ describe('validation', () => {
             {
               conditionType: CompoundConditionType,
               operator: 'or',
-              operands: [testTimeConditionObj, testRpcConditionObj],
+              operands: [
+                testRpcConditionObj,
+                {
+                  conditionType: CompoundConditionType,
+                  operator: 'and',
+                  operands: [
+                    testTimeConditionObj,
+                    {
+                      conditionType: CompoundConditionType,
+                      operator: 'or',
+                      operands: [testTimeConditionObj, testRpcConditionObj],
+                    },
+                  ],
+                },
+              ],
             },
           ],
         },
@@ -227,20 +241,34 @@ describe('validation', () => {
     expect(result.data).toBeUndefined();
     expect(result.error?.format()).toMatchObject({
       operands: {
-        _errors: [`Exceeded max nested depth of 2 for multi-condition type`],
+        _errors: [`Exceeded max nested depth of 4 for multi-condition type`],
       },
     });
   });
   it('limits max depth of nested sequential condition', () => {
+    // Create 5 levels of nesting to exceed max depth of 4
     const result = CompoundCondition.validate(compoundConditionSchema, {
       operator: 'or',
       operands: [
         testRpcConditionObj,
-        testContractConditionObj,
         {
           conditionType: CompoundConditionType,
-          operator: 'not',
-          operands: [testSequentialConditionObj],
+          operator: 'and',
+          operands: [
+            testTimeConditionObj,
+            {
+              conditionType: CompoundConditionType,
+              operator: 'or',
+              operands: [
+                testRpcConditionObj,
+                {
+                  conditionType: CompoundConditionType,
+                  operator: 'not',
+                  operands: [testSequentialConditionObj],
+                },
+              ],
+            },
+          ],
         },
       ],
     });
@@ -248,7 +276,7 @@ describe('validation', () => {
     expect(result.data).toBeUndefined();
     expect(result.error?.format()).toMatchObject({
       operands: {
-        _errors: ['Exceeded max nested depth of 2 for multi-condition type'],
+        _errors: ['Exceeded max nested depth of 4 for multi-condition type'],
       },
     });
   });

--- a/packages/taco/test/conditions/if-then-else-condition.test.ts
+++ b/packages/taco/test/conditions/if-then-else-condition.test.ts
@@ -115,11 +115,23 @@ describe('validation', () => {
   );
 
   it('limits max depth of nested if condition', () => {
+    // Need 5 levels of nesting to exceed max depth of 4
+    // ifThenElse(1) -> ifThenElse(2) -> ifThenElse(3) -> ifThenElse(4) -> compound(5)
     const result = IfThenElseCondition.validate(ifThenElseConditionSchema, {
       ifCondition: {
         conditionType: IfThenElseConditionType,
-        ifCondition: testRpcConditionObj,
-        thenCondition: testCompoundConditionObj,
+        ifCondition: {
+          conditionType: IfThenElseConditionType,
+          ifCondition: {
+            conditionType: IfThenElseConditionType,
+            ifCondition: testRpcConditionObj,
+            thenCondition: testCompoundConditionObj,
+            elseCondition: testTimeConditionObj,
+          },
+          thenCondition: testTimeConditionObj,
+          elseCondition: true,
+        },
+        thenCondition: testTimeConditionObj,
         elseCondition: testTimeConditionObj,
       },
       thenCondition: testRpcConditionObj,
@@ -129,18 +141,30 @@ describe('validation', () => {
     expect(result.data).toBeUndefined();
     expect(result.error?.format()).toMatchObject({
       ifCondition: {
-        _errors: [`Exceeded max nested depth of 2 for multi-condition type`],
+        _errors: [`Exceeded max nested depth of 4 for multi-condition type`],
       },
     });
   });
 
   it('limits max depth of nested then condition', () => {
+    // Need 5 levels of nesting to exceed max depth of 4
+    // ifThenElse(1) -> ifThenElse(2) -> ifThenElse(3) -> ifThenElse(4) -> compound(5)
     const result = IfThenElseCondition.validate(ifThenElseConditionSchema, {
       ifCondition: testRpcConditionObj,
       thenCondition: {
         conditionType: IfThenElseConditionType,
         ifCondition: testRpcConditionObj,
-        thenCondition: testCompoundConditionObj,
+        thenCondition: {
+          conditionType: IfThenElseConditionType,
+          ifCondition: testRpcConditionObj,
+          thenCondition: {
+            conditionType: IfThenElseConditionType,
+            ifCondition: testRpcConditionObj,
+            thenCondition: testCompoundConditionObj,
+            elseCondition: true,
+          },
+          elseCondition: true,
+        },
         elseCondition: true,
       },
       elseCondition: testTimeConditionObj,
@@ -149,27 +173,39 @@ describe('validation', () => {
     expect(result.data).toBeUndefined();
     expect(result.error?.format()).toMatchObject({
       thenCondition: {
-        _errors: [`Exceeded max nested depth of 2 for multi-condition type`],
+        _errors: [`Exceeded max nested depth of 4 for multi-condition type`],
       },
     });
   });
 
   it('limits max depth of nested else condition', () => {
+    // Need 5 levels of nesting to exceed max depth of 4
+    // ifThenElse(1) -> ifThenElse(2) -> ifThenElse(3) -> ifThenElse(4) -> sequential(5)
     const result = IfThenElseCondition.validate(ifThenElseConditionSchema, {
       ifCondition: testRpcConditionObj,
       thenCondition: testTimeConditionObj,
       elseCondition: {
         conditionType: IfThenElseConditionType,
         ifCondition: testRpcConditionObj,
-        thenCondition: testSequentialConditionObj,
-        elseCondition: testTimeConditionObj,
+        thenCondition: testTimeConditionObj,
+        elseCondition: {
+          conditionType: IfThenElseConditionType,
+          ifCondition: testRpcConditionObj,
+          thenCondition: testTimeConditionObj,
+          elseCondition: {
+            conditionType: IfThenElseConditionType,
+            ifCondition: testRpcConditionObj,
+            thenCondition: testSequentialConditionObj,
+            elseCondition: testTimeConditionObj,
+          },
+        },
       },
     });
     expect(result.error).toBeDefined();
     expect(result.data).toBeUndefined();
     expect(result.error?.format()).toMatchObject({
       elseCondition: {
-        _errors: [`Exceeded max nested depth of 2 for multi-condition type`],
+        _errors: [`Exceeded max nested depth of 4 for multi-condition type`],
       },
     });
   });

--- a/packages/taco/test/conditions/sequential.test.ts
+++ b/packages/taco/test/conditions/sequential.test.ts
@@ -264,6 +264,8 @@ describe('validation', () => {
   });
 
   it('limits max depth of nested compound condition', () => {
+    // Need 5 levels of nesting to exceed max depth of 4
+    // sequential(1) -> compound(2) -> compound(3) -> compound(4) -> compound(5)
     const result = SequentialCondition.validate(sequentialConditionSchema, {
       conditionVariables: [
         rpcConditionVariable,
@@ -277,7 +279,21 @@ describe('validation', () => {
               {
                 conditionType: CompoundConditionType,
                 operator: 'and',
-                operands: [testTimeConditionObj, testRpcConditionObj],
+                operands: [
+                  {
+                    conditionType: CompoundConditionType,
+                    operator: 'or',
+                    operands: [
+                      {
+                        conditionType: CompoundConditionType,
+                        operator: 'not',
+                        operands: [testTimeConditionObj],
+                      },
+                      testRpcConditionObj,
+                    ],
+                  },
+                  testTimeConditionObj,
+                ],
               },
             ],
           },
@@ -288,23 +304,64 @@ describe('validation', () => {
     expect(result.data).toBeUndefined();
     expect(result.error?.format()).toMatchObject({
       conditionVariables: {
-        _errors: [`Exceeded max nested depth of 2 for multi-condition type`],
+        _errors: [`Exceeded max nested depth of 4 for multi-condition type`],
       },
     });
   });
 
   it('limits max depth of nested sequential condition', () => {
+    // Need 5 levels of nesting to exceed max depth of 4
+    // sequential(1) -> sequential(2) -> sequential(3) -> sequential(4) -> sequential(5)
     const result = SequentialCondition.validate(sequentialConditionSchema, {
       conditionVariables: [
         rpcConditionVariable,
         contractConditionVariable,
         {
-          varName: 'sequentialNested',
+          varName: 'level2',
           condition: {
             conditionType: SequentialConditionType,
             conditionVariables: [
               timeConditionVariable,
-              nestedSequentialConditionVariable,
+              {
+                varName: 'level3',
+                condition: {
+                  conditionType: SequentialConditionType,
+                  conditionVariables: [
+                    {
+                      varName: 'level4a',
+                      condition: testRpcConditionObj,
+                    },
+                    {
+                      varName: 'level4',
+                      condition: {
+                        conditionType: SequentialConditionType,
+                        conditionVariables: [
+                          {
+                            varName: 'level5a',
+                            condition: testTimeConditionObj,
+                          },
+                          {
+                            varName: 'level5',
+                            condition: {
+                              conditionType: SequentialConditionType,
+                              conditionVariables: [
+                                {
+                                  varName: 'level6a',
+                                  condition: testTimeConditionObj,
+                                },
+                                {
+                                  varName: 'level6b',
+                                  condition: testContractConditionObj,
+                                },
+                              ],
+                            },
+                          },
+                        ],
+                      },
+                    },
+                  ],
+                },
+              },
             ],
           },
         },
@@ -314,7 +371,7 @@ describe('validation', () => {
     expect(result.data).toBeUndefined();
     expect(result.error?.format()).toMatchObject({
       conditionVariables: {
-        _errors: ['Exceeded max nested depth of 2 for multi-condition type'],
+        _errors: ['Exceeded max nested depth of 4 for multi-condition type'],
       },
     });
   });

--- a/packages/taco/test/conditions/sequential.test.ts
+++ b/packages/taco/test/conditions/sequential.test.ts
@@ -112,7 +112,7 @@ describe('validation', () => {
   });
 
   it('rejects > max number of condition variables', () => {
-    const tooManyConditionVariables = new Array(11);
+    const tooManyConditionVariables = new Array(21);
     for (let i = 0; i < tooManyConditionVariables.length; i++) {
       tooManyConditionVariables[i] = {
         varName: `var${i}`,
@@ -127,7 +127,7 @@ describe('validation', () => {
     expect(result.data).toBeUndefined();
     expect(result.error?.format()).toMatchObject({
       conditionVariables: {
-        _errors: ['Array must contain at most 10 element(s)'],
+        _errors: ['Array must contain at most 20 element(s)'],
       },
     });
   });

--- a/packages/taco/test/conditions/variable-operation.test.ts
+++ b/packages/taco/test/conditions/variable-operation.test.ts
@@ -50,34 +50,34 @@ describe('validates schema', () => {
   );
 });
 
-describe('*pow= operator', () => {
-  it('validates *pow= operator with array value', () => {
+describe('toTokenBaseUnits operator', () => {
+  it('validates toTokenBaseUnits operator with decimals value', () => {
     const result = variableOperationSchema.safeParse({
-      operation: '*pow=',
-      value: [10, 18],
+      operation: 'toTokenBaseUnits',
+      value: 18,
     });
     expect(result.success).toBe(true);
     expect(result.data).toEqual({
-      operation: '*pow=',
-      value: [10, 18],
+      operation: 'toTokenBaseUnits',
+      value: 18,
     });
   });
 
-  it('validates *pow= operator with context parameter in array', () => {
+  it('validates toTokenBaseUnits operator with context parameter', () => {
     const result = variableOperationSchema.safeParse({
-      operation: '*pow=',
-      value: [10, ':tokenDecimals'],
+      operation: 'toTokenBaseUnits',
+      value: ':tokenDecimals',
     });
     expect(result.success).toBe(true);
     expect(result.data).toEqual({
-      operation: '*pow=',
-      value: [10, ':tokenDecimals'],
+      operation: 'toTokenBaseUnits',
+      value: ':tokenDecimals',
     });
   });
 
-  it('rejects *pow= operator without value', () => {
+  it('rejects toTokenBaseUnits operator without value', () => {
     const result = variableOperationSchema.safeParse({
-      operation: '*pow=',
+      operation: 'toTokenBaseUnits',
     });
     expect(result.success).toBe(false);
     expect(result.error!.format()).toMatchObject({

--- a/packages/taco/test/conditions/variable-operation.test.ts
+++ b/packages/taco/test/conditions/variable-operation.test.ts
@@ -49,3 +49,41 @@ describe('validates schema', () => {
     },
   );
 });
+
+describe('exponent operator', () => {
+  it('validates **= operator with numeric value', () => {
+    const result = variableOperationSchema.safeParse({
+      operation: '**=',
+      value: 18,
+    });
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual({
+      operation: '**=',
+      value: 18,
+    });
+  });
+
+  it('validates **= operator with context parameter', () => {
+    const result = variableOperationSchema.safeParse({
+      operation: '**=',
+      value: ':tokenDecimals',
+    });
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual({
+      operation: '**=',
+      value: ':tokenDecimals',
+    });
+  });
+
+  it('rejects **= operator without value', () => {
+    const result = variableOperationSchema.safeParse({
+      operation: '**=',
+    });
+    expect(result.success).toBe(false);
+    expect(result.error!.format()).toMatchObject({
+      value: {
+        _errors: ['Value must be defined for operation'],
+      },
+    });
+  });
+});

--- a/packages/taco/test/conditions/variable-operation.test.ts
+++ b/packages/taco/test/conditions/variable-operation.test.ts
@@ -50,34 +50,34 @@ describe('validates schema', () => {
   );
 });
 
-describe('pow operator', () => {
-  it('validates pow operator with array value', () => {
+describe('*pow= operator', () => {
+  it('validates *pow= operator with array value', () => {
     const result = variableOperationSchema.safeParse({
-      operation: 'pow',
+      operation: '*pow=',
       value: [10, 18],
     });
     expect(result.success).toBe(true);
     expect(result.data).toEqual({
-      operation: 'pow',
+      operation: '*pow=',
       value: [10, 18],
     });
   });
 
-  it('validates pow operator with context parameter in array', () => {
+  it('validates *pow= operator with context parameter in array', () => {
     const result = variableOperationSchema.safeParse({
-      operation: 'pow',
+      operation: '*pow=',
       value: [10, ':tokenDecimals'],
     });
     expect(result.success).toBe(true);
     expect(result.data).toEqual({
-      operation: 'pow',
+      operation: '*pow=',
       value: [10, ':tokenDecimals'],
     });
   });
 
-  it('rejects pow operator without value', () => {
+  it('rejects *pow= operator without value', () => {
     const result = variableOperationSchema.safeParse({
-      operation: 'pow',
+      operation: '*pow=',
     });
     expect(result.success).toBe(false);
     expect(result.error!.format()).toMatchObject({

--- a/packages/taco/test/conditions/variable-operation.test.ts
+++ b/packages/taco/test/conditions/variable-operation.test.ts
@@ -50,34 +50,34 @@ describe('validates schema', () => {
   );
 });
 
-describe('exponent operator', () => {
-  it('validates **= operator with numeric value', () => {
+describe('pow operator', () => {
+  it('validates pow operator with array value', () => {
     const result = variableOperationSchema.safeParse({
-      operation: '**=',
-      value: 18,
+      operation: 'pow',
+      value: [10, 18],
     });
     expect(result.success).toBe(true);
     expect(result.data).toEqual({
-      operation: '**=',
-      value: 18,
+      operation: 'pow',
+      value: [10, 18],
     });
   });
 
-  it('validates **= operator with context parameter', () => {
+  it('validates pow operator with context parameter in array', () => {
     const result = variableOperationSchema.safeParse({
-      operation: '**=',
-      value: ':tokenDecimals',
+      operation: 'pow',
+      value: [10, ':tokenDecimals'],
     });
     expect(result.success).toBe(true);
     expect(result.data).toEqual({
-      operation: '**=',
-      value: ':tokenDecimals',
+      operation: 'pow',
+      value: [10, ':tokenDecimals'],
     });
   });
 
-  it('rejects **= operator without value', () => {
+  it('rejects pow operator without value', () => {
     const result = variableOperationSchema.safeParse({
-      operation: '**=',
+      operation: 'pow',
     });
     expect(result.success).toBe(false);
     expect(result.error!.format()).toMatchObject({


### PR DESCRIPTION
## Summary

Increases flexibility for complex condition hierarchies and adds new operator functionality.

## Changes

- **Increase max nested depth from 2 to 4** for compound, if-then-else, and sequential conditions
- **Increase max sequential condition variables from 10 to 20**
- **Add `toTokenBaseUnits` operator** to variable operations for token decimal calculations

## Testing

- Updated existing depth validation tests to use 5 levels of nesting (to exceed the new max of 4)
- Added new tests for exponent operator with numeric values, context parameters, and missing value validation