### PR TITLE
feat(taco): Add timeout parameter to signUserOp

### DIFF
--- a/packages/shared/src/porter.ts
+++ b/packages/shared/src/porter.ts
@@ -165,6 +165,7 @@ type PostTacoSignRequest = {
     Base64EncodedBytes
   >;
   readonly threshold: number;
+  readonly timeout?: number;
 };
 
 type TacoSignResponse = {
@@ -339,6 +340,7 @@ export class PorterClient {
       EncryptedThresholdSignatureRequest
     >,
     threshold: number,
+    timeout?: number,
   ): Promise<TacoSignResult> {
     const data: PostTacoSignRequest = {
       encrypted_signing_requests: Object.fromEntries(
@@ -350,6 +352,7 @@ export class PorterClient {
         ),
       ),
       threshold,
+      ...(timeout !== undefined && { timeout }),
     };
 
     const resp: AxiosResponse<TacoSignResponse> = await this.tryAndCall({

--- a/packages/taco/src/sign.ts
+++ b/packages/taco/src/sign.ts
@@ -151,6 +151,7 @@ async function makeSigningRequests(
  * @param aaVersion - The AA version of the account abstraction to use for signing.
  * @param context - Optional condition context for the context variable resolution.
  * @param porterUris - Optional URIs for the Porter service. If not provided, will fetch the default URIs from the domain.
+ * @param timeout - Optional timeout in seconds for the Porter signing request.
  * @returns A promise that resolves to a SignResult containing the message hash, aggregated signature, and signing results from the Porter service.
  * @throws An error if the signing process fails due to insufficient signatures or mismatched hashes.
  */
@@ -163,6 +164,7 @@ export async function signUserOp(
   aaVersion: 'mdt' | '0.8.0' | string,
   context?: ConditionContext,
   porterUris?: string[],
+  timeout?: number,
 ): Promise<SignResult> {
   const porterUrisFull: string[] = porterUris
     ? porterUris
@@ -194,6 +196,7 @@ export async function signUserOp(
   const { encryptedResponses, errors } = await porter.signUserOp(
     encryptedRequests,
     threshold,
+    timeout,
   );
   if (Object.keys(encryptedResponses).length < threshold) {
     // not enough signatures returned

--- a/packages/taco/test/taco-sign.test.ts
+++ b/packages/taco/test/taco-sign.test.ts
@@ -404,6 +404,7 @@ describe('TACo Signing', () => {
             '0xnode2': expect.any(EncryptedThresholdSignatureRequest),
           },
           threshold,
+          undefined,
         );
 
         const call = porterSignUserOpMock.mock.calls.at(-1)!;
@@ -482,6 +483,7 @@ describe('TACo Signing', () => {
           '0xnode2': expect.any(EncryptedThresholdSignatureRequest),
         },
         threshold,
+        undefined,
       );
       const call = porterSignUserOpMock.mock.calls.at(-1)!;
       const [op] = call;


### PR DESCRIPTION
Add optional timeout parameter to control how long Porter waits for nodes to respond during signing operations. This allows callers to increase the timeout beyond Porter's default 30 seconds when needed.

This functionality is already exposed by Porters `/sign` endpoint, it was just never brought over to `taco-web`