### PR TITLE
feat(taco): Add create2 operation for local address computation

### DIFF
--- a/packages/taco/schema-docs/condition-schemas.md
+++ b/packages/taco/schema-docs/condition-schemas.md
@@ -381,14 +381,10 @@ _(\*) Required._
 
 An operation that can be performed on an obtained result.
 
-_Object containing the following properties:_
+_Union of the following possible types:_
 
-| Property             | Type                                                                                                                                                                                                                                                                                                                                                                                                                                      |
-| :------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **`operation`** (\*) | `'+=' \| '-=' \| '*=' \| '/=' \| '%=' \| 'toTokenBaseUnits' \| 'index' \| 'round' \| 'abs' \| 'avg' \| 'ceil' \| 'ethToWei' \| 'floor' \| 'len' \| 'max' \| 'min' \| 'sum' \| 'weiToEth' \| 'bool' \| 'float' \| ...`                                                                                                                                                                                                                     |
-| `value`              | [ParamOrContextParam](#paramorcontextparam) _or_ _Object with properties:_<ul><li>`deployerAddress`: `string` (_regex: `/^0x[0-9a-fA-F]+$/`_) _or_ [ContextParam](#contextparam)</li><li>`bytecodeHash`: `string` (_regex: `/^0x[0-9a-fA-F]+$/`_) _or_ [ContextParam](#contextparam)</li></ul> Description: Value for create2 operation containing deployerAddress and bytecodeHash for computing CREATE2 addresses locally.<br /> <br /> |
-
-_(\*) Required._
+- _Object with properties:_<ul><li>`operation`: `'+=' | '-=' | '*=' | '/=' | '%=' | 'toTokenBaseUnits' | 'index' | 'round' | 'abs' | 'avg' | 'ceil' | 'ethToWei' | 'floor' | 'len' | 'max' | 'min' | 'sum' | 'weiToEth' | 'bool' | 'float' | ...`</li><li>`value`: [ParamOrContextParam](#paramorcontextparam)</li></ul>
+- _Object with properties:_<ul><li>`operation`: `'create2'`</li><li>`value`: _Object with properties:_<ul><li>`deployerAddress`: `string` (_regex: `/^0x[0-9a-fA-F]+$/`_) _or_ [ContextParam](#contextparam)</li><li>`bytecodeHash`: `string` (_regex: `/^0x[0-9a-fA-F]+$/`_) _or_ [ContextParam](#contextparam)</li></ul> - Value for create2 operation containing deployerAddress and bytecodeHash for computing CREATE2 addresses locally.</li></ul>
 
 ## VariableOperationsArray
 

--- a/packages/taco/schema-docs/condition-schemas.md
+++ b/packages/taco/schema-docs/condition-schemas.md
@@ -383,10 +383,10 @@ An operation that can be performed on an obtained result.
 
 _Object containing the following properties:_
 
-| Property             | Type                                                                                                                                                                                                                  |
-| :------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **`operation`** (\*) | `'+=' \| '-=' \| '*=' \| '/=' \| '%=' \| 'toTokenBaseUnits' \| 'index' \| 'round' \| 'abs' \| 'avg' \| 'ceil' \| 'ethToWei' \| 'floor' \| 'len' \| 'max' \| 'min' \| 'sum' \| 'weiToEth' \| 'bool' \| 'float' \| ...` |
-| `value`              | [ParamOrContextParam](#paramorcontextparam)                                                                                                                                                                           |
+| Property             | Type                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| :------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`operation`** (\*) | `'+=' \| '-=' \| '*=' \| '/=' \| '%=' \| 'toTokenBaseUnits' \| 'index' \| 'round' \| 'abs' \| 'avg' \| 'ceil' \| 'ethToWei' \| 'floor' \| 'len' \| 'max' \| 'min' \| 'sum' \| 'weiToEth' \| 'bool' \| 'float' \| ...`                                                                                                                                                                                                                     |
+| `value`              | [ParamOrContextParam](#paramorcontextparam) _or_ _Object with properties:_<ul><li>`deployerAddress`: `string` (_regex: `/^0x[0-9a-fA-F]+$/`_) _or_ [ContextParam](#contextparam)</li><li>`bytecodeHash`: `string` (_regex: `/^0x[0-9a-fA-F]+$/`_) _or_ [ContextParam](#contextparam)</li></ul> Description: Value for create2 operation containing deployerAddress and bytecodeHash for computing CREATE2 addresses locally.<br /> <br /> |
 
 _(\*) Required._
 

--- a/packages/taco/src/conditions/schemas/context.ts
+++ b/packages/taco/src/conditions/schemas/context.ts
@@ -25,16 +25,6 @@ const paramSchema = z.union([
   z.bigint(),
 ]);
 
-// Schema for CREATE2 operation value - supports both literal addresses/hashes and context parameters
-export const create2ValueSchema = z
-  .object({
-    deployerAddress: z.union([plainStringSchema, contextParamSchema]),
-    bytecodeHash: z.union([plainStringSchema, contextParamSchema]),
-  })
-  .describe(
-    'Value for create2 operation containing deployerAddress and bytecodeHash for computing CREATE2 addresses locally.',
-  );
-
 const blockchainParamSchema = z
   .union([
     plainStringSchema,
@@ -50,7 +40,6 @@ export const paramOrContextParamSchema: z.ZodSchema = z.union([
   paramSchema,
   contextParamSchema,
   z.lazy(() => z.array(paramOrContextParamSchema)),
-  create2ValueSchema,
 ]);
 
 export const blockchainParamOrContextParamSchema: z.ZodSchema = z.union([

--- a/packages/taco/src/conditions/schemas/context.ts
+++ b/packages/taco/src/conditions/schemas/context.ts
@@ -25,6 +25,16 @@ const paramSchema = z.union([
   z.bigint(),
 ]);
 
+// Schema for CREATE2 operation value - supports both literal addresses/hashes and context parameters
+export const create2ValueSchema = z
+  .object({
+    deployerAddress: z.union([plainStringSchema, contextParamSchema]),
+    bytecodeHash: z.union([plainStringSchema, contextParamSchema]),
+  })
+  .describe(
+    'Value for create2 operation containing deployerAddress and bytecodeHash for computing CREATE2 addresses locally.',
+  );
+
 const blockchainParamSchema = z
   .union([
     plainStringSchema,
@@ -40,6 +50,7 @@ export const paramOrContextParamSchema: z.ZodSchema = z.union([
   paramSchema,
   contextParamSchema,
   z.lazy(() => z.array(paramOrContextParamSchema)),
+  create2ValueSchema,
 ]);
 
 export const blockchainParamOrContextParamSchema: z.ZodSchema = z.union([

--- a/packages/taco/src/conditions/schemas/variable-operation.ts
+++ b/packages/taco/src/conditions/schemas/variable-operation.ts
@@ -1,6 +1,19 @@
 import { z } from 'zod';
 
-import { create2ValueSchema, paramOrContextParamSchema } from './context';
+import { contextParamSchema, paramOrContextParamSchema } from './context';
+
+const hexPrefixedStringSchema = z
+  .string()
+  .regex(/^0x[0-9a-fA-F]+$/, 'Must be a 0x-prefixed hex string');
+
+const create2ValueSchema = z
+  .object({
+    deployerAddress: z.union([hexPrefixedStringSchema, contextParamSchema]),
+    bytecodeHash: z.union([hexPrefixedStringSchema, contextParamSchema]),
+  })
+  .describe(
+    'Value for create2 operation containing deployerAddress and bytecodeHash for computing CREATE2 addresses locally.',
+  );
 
 export const OPERATOR_FUNCTIONS = [
   '+=',
@@ -68,7 +81,7 @@ export const UNARY_OPERATOR_FUNCTIONS = [
 export const variableOperationSchema = z
   .object({
     operation: z.enum(OPERATOR_FUNCTIONS),
-    value: paramOrContextParamSchema.optional(),
+    value: z.union([paramOrContextParamSchema, create2ValueSchema]).optional(),
   })
   .refine(
     (data) => {
@@ -110,6 +123,21 @@ export const variableOperationSchema = z
     {
       message:
         'create2 operation requires an object with deployerAddress and bytecodeHash',
+      path: ['value'],
+    },
+  )
+  .refine(
+    (data) => {
+      if (
+        data.operation !== 'create2' &&
+        create2ValueSchema.safeParse(data.value).success
+      ) {
+        return false;
+      }
+      return true;
+    },
+    {
+      message: 'create2-shaped values are only valid for the create2 operation',
       path: ['value'],
     },
   )

--- a/packages/taco/src/conditions/schemas/variable-operation.ts
+++ b/packages/taco/src/conditions/schemas/variable-operation.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-import { paramOrContextParamSchema } from './context';
+import { create2ValueSchema, paramOrContextParamSchema } from './context';
 
 export const OPERATOR_FUNCTIONS = [
   '+=',
@@ -35,6 +35,8 @@ export const OPERATOR_FUNCTIONS = [
   'toHex',
   // hashing
   'keccak',
+  // address computation
+  'create2',
 ] as const;
 
 export const UNARY_OPERATOR_FUNCTIONS = [
@@ -95,6 +97,19 @@ export const variableOperationSchema = z
     },
     {
       message: 'Value must be defined for operation',
+      path: ['value'],
+    },
+  )
+  .refine(
+    (data) => {
+      if (data.operation === 'create2') {
+        return create2ValueSchema.safeParse(data.value).success;
+      }
+      return true;
+    },
+    {
+      message:
+        'create2 operation requires an object with deployerAddress and bytecodeHash',
       path: ['value'],
     },
   )

--- a/packages/taco/src/conditions/schemas/variable-operation.ts
+++ b/packages/taco/src/conditions/schemas/variable-operation.ts
@@ -7,10 +7,17 @@ const hexPrefixedStringSchema = z
   .regex(/^0x[0-9a-fA-F]+$/, 'Must be a 0x-prefixed hex string');
 
 const create2ValueSchema = z
-  .object({
-    deployerAddress: z.union([hexPrefixedStringSchema, contextParamSchema]),
-    bytecodeHash: z.union([hexPrefixedStringSchema, contextParamSchema]),
-  })
+  .object(
+    {
+      deployerAddress: z.union([hexPrefixedStringSchema, contextParamSchema]),
+      bytecodeHash: z.union([hexPrefixedStringSchema, contextParamSchema]),
+    },
+    {
+      required_error: 'Value must be defined for operation',
+      invalid_type_error:
+        'create2 operation requires an object with deployerAddress and bytecodeHash',
+    },
+  )
   .describe(
     'Value for create2 operation containing deployerAddress and bytecodeHash for computing CREATE2 addresses locally.',
   );
@@ -78,10 +85,20 @@ export const UNARY_OPERATOR_FUNCTIONS = [
   'keccak',
 ];
 
-export const variableOperationSchema = z
-  .object({
-    operation: z.enum(OPERATOR_FUNCTIONS),
-    value: z.union([paramOrContextParamSchema, create2ValueSchema]).optional(),
+const baseVariableOperationSchema = z.object({
+  operation: z.enum(OPERATOR_FUNCTIONS),
+  value: z.any().optional(),
+});
+
+const commonVariableOperationSchema = baseVariableOperationSchema
+  .extend({
+    operation: z.enum(
+      OPERATOR_FUNCTIONS.filter((op) => op !== 'create2') as [
+        string,
+        ...string[],
+      ],
+    ),
+    value: paramOrContextParamSchema.optional(),
   })
   .refine(
     (data) => {
@@ -112,35 +129,15 @@ export const variableOperationSchema = z
       message: 'Value must be defined for operation',
       path: ['value'],
     },
-  )
-  .refine(
-    (data) => {
-      if (data.operation === 'create2') {
-        return create2ValueSchema.safeParse(data.value).success;
-      }
-      return true;
-    },
-    {
-      message:
-        'create2 operation requires an object with deployerAddress and bytecodeHash',
-      path: ['value'],
-    },
-  )
-  .refine(
-    (data) => {
-      if (
-        data.operation !== 'create2' &&
-        create2ValueSchema.safeParse(data.value).success
-      ) {
-        return false;
-      }
-      return true;
-    },
-    {
-      message: 'create2-shaped values are only valid for the create2 operation',
-      path: ['value'],
-    },
-  )
+  );
+
+const create2VariableOperationSchema = baseVariableOperationSchema.extend({
+  operation: z.literal('create2'),
+  value: create2ValueSchema,
+});
+
+export const variableOperationSchema = z
+  .union([commonVariableOperationSchema, create2VariableOperationSchema])
   .describe('An operation that can be performed on an obtained result.');
 
 export const MAX_VARIABLE_OPERATIONS = 5;

--- a/packages/taco/test/conditions/return-value-test.test.ts
+++ b/packages/taco/test/conditions/return-value-test.test.ts
@@ -3,12 +3,12 @@ import { describe, expect, it } from 'vitest';
 import {
   MAX_VARIABLE_OPERATIONS,
   OPERATOR_FUNCTIONS,
-  UNARY_OPERATOR_FUNCTIONS,
 } from '../../src/conditions/schemas/variable-operation';
 import {
   blockchainReturnValueTestSchema,
   returnValueTestSchema,
 } from '../../src/conditions/shared';
+import { getTestValueForOperation } from '../test-utils';
 
 [blockchainReturnValueTestSchema, returnValueTestSchema].forEach((schema) => {
   describe('validates schema', () => {
@@ -76,7 +76,7 @@ import {
         operations: [
           {
             operation: operation,
-            value: UNARY_OPERATOR_FUNCTIONS.includes(operation) ? undefined : 5,
+            value: getTestValueForOperation(operation),
           },
         ],
       });

--- a/packages/taco/test/conditions/sequential.test.ts
+++ b/packages/taco/test/conditions/sequential.test.ts
@@ -6,7 +6,6 @@ import { IfThenElseConditionType } from '../../src/conditions/if-then-else-condi
 import {
   MAX_VARIABLE_OPERATIONS,
   OPERATOR_FUNCTIONS,
-  UNARY_OPERATOR_FUNCTIONS,
 } from '../../src/conditions/schemas/variable-operation';
 import {
   ConditionVariableProps,
@@ -16,6 +15,7 @@ import {
   SequentialConditionType,
 } from '../../src/conditions/sequential';
 import {
+  getTestValueForOperation,
   testCompoundConditionObj,
   testContractConditionObj,
   testJsonApiConditionObj,
@@ -449,6 +449,7 @@ describe('validation', () => {
     });
     expect(condition.value.conditionType).toEqual(SequentialConditionType);
   });
+
   it.each(OPERATOR_FUNCTIONS)('allows valid operations', (operation) => {
     const conditionObj = {
       conditionType: SequentialConditionType,
@@ -459,9 +460,7 @@ describe('validation', () => {
           operations: [
             {
               operation: operation,
-              value: UNARY_OPERATOR_FUNCTIONS.includes(operation)
-                ? undefined
-                : 5,
+              value: getTestValueForOperation(operation),
             },
           ],
         },

--- a/packages/taco/test/conditions/variable-operation.test.ts
+++ b/packages/taco/test/conditions/variable-operation.test.ts
@@ -7,9 +7,6 @@ import {
 } from '../../src/conditions/schemas/variable-operation';
 import { getTestValueForOperation } from '../test-utils';
 
-// Operations that require a specific value type (not a simple primitive)
-const OBJECT_VALUE_OPERATIONS = ['create2'];
-
 describe('validates schema', () => {
   it.each(OPERATOR_FUNCTIONS)('allows valid operation', (operation) => {
     const result = variableOperationSchema.safeParse({
@@ -36,11 +33,7 @@ describe('validates schema', () => {
   );
 
   it.each(
-    OPERATOR_FUNCTIONS.filter(
-      (op) =>
-        !UNARY_OPERATOR_FUNCTIONS.includes(op) &&
-        !OBJECT_VALUE_OPERATIONS.includes(op),
-    ),
+    OPERATOR_FUNCTIONS.filter((op) => !UNARY_OPERATOR_FUNCTIONS.includes(op)),
   )(
     'disallows operations when value is not provided for operation that requires a value',
     (operation) => {
@@ -49,11 +42,9 @@ describe('validates schema', () => {
         // value is missing for these operations
       });
       expect(result.success).toBe(false);
-      expect(result.error!.format()).toMatchObject({
-        value: {
-          _errors: ['Value must be defined for operation'],
-        },
-      });
+      expect(result.error!.format().value?._errors).toContain(
+        'Value must be defined for operation',
+      );
     },
   );
 });

--- a/packages/taco/test/conditions/variable-operation.test.ts
+++ b/packages/taco/test/conditions/variable-operation.test.ts
@@ -177,4 +177,23 @@ describe('create2 operator', () => {
     });
     expect(result.success).toBe(false);
   });
+
+  it.each(
+    OPERATOR_FUNCTIONS.filter(
+      (op) => !UNARY_OPERATOR_FUNCTIONS.includes(op) && op !== 'create2',
+    ),
+  )(
+    'rejects create2-shaped value for non-create2 operation %s',
+    (operation) => {
+      const result = variableOperationSchema.safeParse({
+        operation,
+        value: {
+          deployerAddress: '0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f',
+          bytecodeHash:
+            '0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f',
+        },
+      });
+      expect(result.success).toBe(false);
+    },
+  );
 });

--- a/packages/taco/test/conditions/variable-operation.test.ts
+++ b/packages/taco/test/conditions/variable-operation.test.ts
@@ -5,12 +5,16 @@ import {
   UNARY_OPERATOR_FUNCTIONS,
   variableOperationSchema,
 } from '../../src/conditions/schemas/variable-operation';
+import { getTestValueForOperation } from '../test-utils';
+
+// Operations that require a specific value type (not a simple primitive)
+const OBJECT_VALUE_OPERATIONS = ['create2'];
 
 describe('validates schema', () => {
   it.each(OPERATOR_FUNCTIONS)('allows valid operation', (operation) => {
     const result = variableOperationSchema.safeParse({
       operation: operation,
-      value: UNARY_OPERATOR_FUNCTIONS.includes(operation) ? undefined : 5,
+      value: getTestValueForOperation(operation),
     });
     expect(result.success).toBe(true);
     expect(result.error).toBeUndefined();
@@ -32,7 +36,11 @@ describe('validates schema', () => {
   );
 
   it.each(
-    OPERATOR_FUNCTIONS.filter((op) => !UNARY_OPERATOR_FUNCTIONS.includes(op)),
+    OPERATOR_FUNCTIONS.filter(
+      (op) =>
+        !UNARY_OPERATOR_FUNCTIONS.includes(op) &&
+        !OBJECT_VALUE_OPERATIONS.includes(op),
+    ),
   )(
     'disallows operations when value is not provided for operation that requires a value',
     (operation) => {
@@ -85,5 +93,95 @@ describe('toTokenBaseUnits operator', () => {
         _errors: ['Value must be defined for operation'],
       },
     });
+  });
+});
+
+describe('create2 operator', () => {
+  it('validates create2 operator with deployerAddress and bytecodeHash', () => {
+    const result = variableOperationSchema.safeParse({
+      operation: 'create2',
+      value: {
+        deployerAddress: '0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f',
+        bytecodeHash:
+          '0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f',
+      },
+    });
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual({
+      operation: 'create2',
+      value: {
+        deployerAddress: '0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f',
+        bytecodeHash:
+          '0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f',
+      },
+    });
+  });
+
+  it('validates create2 operator with context parameters', () => {
+    const result = variableOperationSchema.safeParse({
+      operation: 'create2',
+      value: {
+        deployerAddress: ':factoryAddress',
+        bytecodeHash: ':initCodeHash',
+      },
+    });
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual({
+      operation: 'create2',
+      value: {
+        deployerAddress: ':factoryAddress',
+        bytecodeHash: ':initCodeHash',
+      },
+    });
+  });
+
+  it('validates create2 operator with mixed literal and context parameter', () => {
+    const result = variableOperationSchema.safeParse({
+      operation: 'create2',
+      value: {
+        deployerAddress: '0x69Aa2f9fe1572F1B640E1bbc512f5c3a734fc77c',
+        bytecodeHash: ':initCodeHash',
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects create2 operator without value', () => {
+    const result = variableOperationSchema.safeParse({
+      operation: 'create2',
+    });
+    expect(result.success).toBe(false);
+    // Multiple validation errors occur: missing value + invalid create2 value structure
+    const errors = result.error!.format().value?._errors ?? [];
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it('rejects create2 operator with missing deployerAddress', () => {
+    const result = variableOperationSchema.safeParse({
+      operation: 'create2',
+      value: {
+        bytecodeHash:
+          '0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f',
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects create2 operator with missing bytecodeHash', () => {
+    const result = variableOperationSchema.safeParse({
+      operation: 'create2',
+      value: {
+        deployerAddress: '0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f',
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects create2 operator with primitive value', () => {
+    const result = variableOperationSchema.safeParse({
+      operation: 'create2',
+      value: 5,
+    });
+    expect(result.success).toBe(false);
   });
 });

--- a/packages/taco/test/conditions/variable-operation.test.ts
+++ b/packages/taco/test/conditions/variable-operation.test.ts
@@ -42,9 +42,11 @@ describe('validates schema', () => {
         // value is missing for these operations
       });
       expect(result.success).toBe(false);
-      expect(result.error!.format().value?._errors).toContain(
-        'Value must be defined for operation',
-      );
+      expect(result.error!.format()).toMatchObject({
+        value: {
+          _errors: ['Value must be defined for operation'],
+        },
+      });
     },
   );
 });

--- a/packages/taco/test/test-utils.ts
+++ b/packages/taco/test/test-utils.ts
@@ -98,6 +98,7 @@ import {
   JsonRpcConditionProps,
   JsonRpcConditionType,
 } from '../src/conditions/schemas/json-rpc';
+import { UNARY_OPERATOR_FUNCTIONS } from '../src/conditions/schemas/variable-operation';
 import {
   SequentialConditionProps,
   SequentialConditionType,
@@ -108,6 +109,24 @@ import {
 } from '../src/conditions/shared';
 import { DkgClient, DkgRitual } from '../src/dkg';
 import { encryptMessage } from '../src/tdec';
+
+/**
+ * Returns a valid test value for the given operation type.
+ * Used in parameterized tests that iterate over OPERATOR_FUNCTIONS.
+ */
+export const getTestValueForOperation = (operation: string) => {
+  if (UNARY_OPERATOR_FUNCTIONS.includes(operation)) {
+    return undefined;
+  }
+  if (operation === 'create2') {
+    return {
+      deployerAddress: '0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f',
+      bytecodeHash:
+        '0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f',
+    };
+  }
+  return 5;
+};
 
 export const fakeDkgTDecFlowE2E: (
   ritualId?: number,


### PR DESCRIPTION
Add a new create2 operation to the variable operation system that computes Ethereum CREATE2 addresses locally, eliminating RPC calls to factory contracts for counterfactual address resolution.

The operation takes an object value with deployerAddress and bytecodeHash fields, both supporting context variable resolution. This enables full Account Abstraction address derivation pipelines.

Implements taco-web equivalent of nucypher/nucypher#3703.