### PR TITLE
Add in-memory cache to SigningCoordinatorAgent

### DIFF
--- a/packages/shared/src/cache.ts
+++ b/packages/shared/src/cache.ts
@@ -1,0 +1,25 @@
+export class TtlCache {
+  private readonly ttlMs: number;
+  private readonly store = new Map<string, { data: unknown; expiry: number }>();
+
+  constructor(ttlMs: number) {
+    this.ttlMs = ttlMs;
+  }
+
+  get<T>(key: string): T | undefined {
+    const entry = this.store.get(key);
+    if (entry && Date.now() < entry.expiry) {
+      return entry.data as T;
+    }
+    this.store.delete(key);
+    return undefined;
+  }
+
+  set(key: string, data: unknown): void {
+    this.store.set(key, { data, expiry: Date.now() + this.ttlMs });
+  }
+
+  clear(): void {
+    this.store.clear();
+  }
+}

--- a/packages/shared/src/contracts/agents/signing-coordinator.ts
+++ b/packages/shared/src/contracts/agents/signing-coordinator.ts
@@ -14,15 +14,39 @@ export type SignerInfo = {
 };
 
 export class SigningCoordinatorAgent {
+  private static readonly CACHE_TTL_MS = 10_000;
+  private static cache = new Map<string, { data: unknown; expiry: number }>();
+
+  private static getCached<T>(key: string): T | undefined {
+    const entry = this.cache.get(key);
+    if (entry && Date.now() < entry.expiry) {
+      return entry.data as T;
+    }
+    this.cache.delete(key);
+    return undefined;
+  }
+
+  private static setCache(key: string, data: unknown): void {
+    this.cache.set(key, { data, expiry: Date.now() + this.CACHE_TTL_MS });
+  }
+
+  public static clearCache(): void {
+    this.cache.clear();
+  }
+
   public static async getParticipants(
     provider: ethers.providers.Provider,
     domain: Domain,
     cohortId: number,
   ): Promise<SignerInfo[]> {
+    const cacheKey = `participants:${domain}:${cohortId}`;
+    const cached = this.getCached<SignerInfo[]>(cacheKey);
+    if (cached !== undefined) return cached;
+
     const coordinator = await this.connectReadOnly(provider, domain);
     const participants = await coordinator.getSigners(cohortId);
 
-    return participants.map(
+    const result = participants.map(
       (
         participant: SigningCoordinator.SigningCohortParticipantStructOutput,
       ) => {
@@ -35,6 +59,9 @@ export class SigningCoordinatorAgent {
         };
       },
     );
+
+    this.setCache(cacheKey, result);
+    return result;
   }
 
   public static async getThreshold(
@@ -42,9 +69,16 @@ export class SigningCoordinatorAgent {
     domain: Domain,
     cohortId: number,
   ): Promise<number> {
+    const cacheKey = `threshold:${domain}:${cohortId}`;
+    const cached = this.getCached<number>(cacheKey);
+    if (cached !== undefined) return cached;
+
     const coordinator = await this.connectReadOnly(provider, domain);
     const cohort = await coordinator.signingCohorts(cohortId);
-    return cohort.threshold;
+    const result = cohort.threshold;
+
+    this.setCache(cacheKey, result);
+    return result;
   }
 
   public static async getSigningCohortConditions(

--- a/packages/shared/src/contracts/agents/signing-coordinator.ts
+++ b/packages/shared/src/contracts/agents/signing-coordinator.ts
@@ -17,6 +17,14 @@ export type SignerInfo = {
 export class SigningCoordinatorAgent {
   private static cache = new TtlCache(60_000);
 
+  private static cacheKey(
+    domain: Domain,
+    cohortId: number,
+    field: string,
+  ): string {
+    return `${domain}:${cohortId}:${field}`;
+  }
+
   public static clearCache(): void {
     this.cache.clear();
   }
@@ -26,8 +34,8 @@ export class SigningCoordinatorAgent {
     domain: Domain,
     cohortId: number,
   ): Promise<SignerInfo[]> {
-    const cacheKey = `participants:${domain}:${cohortId}`;
-    const cached = this.cache.get<SignerInfo[]>(cacheKey);
+    const key = this.cacheKey(domain, cohortId, 'participants');
+    const cached = this.cache.get<SignerInfo[]>(key);
     if (cached !== undefined) return cached;
 
     const coordinator = await this.connectReadOnly(provider, domain);
@@ -47,7 +55,7 @@ export class SigningCoordinatorAgent {
       },
     );
 
-    this.cache.set(cacheKey, result);
+    this.cache.set(key, result);
     return result;
   }
 
@@ -56,15 +64,15 @@ export class SigningCoordinatorAgent {
     domain: Domain,
     cohortId: number,
   ): Promise<number> {
-    const cacheKey = `threshold:${domain}:${cohortId}`;
-    const cached = this.cache.get<number>(cacheKey);
+    const key = this.cacheKey(domain, cohortId, 'threshold');
+    const cached = this.cache.get<number>(key);
     if (cached !== undefined) return cached;
 
     const coordinator = await this.connectReadOnly(provider, domain);
     const cohort = await coordinator.signingCohorts(cohortId);
     const result = cohort.threshold;
 
-    this.cache.set(cacheKey, result);
+    this.cache.set(key, result);
     return result;
   }
 

--- a/packages/shared/src/contracts/agents/signing-coordinator.ts
+++ b/packages/shared/src/contracts/agents/signing-coordinator.ts
@@ -2,6 +2,7 @@ import { getContract } from '@nucypher/nucypher-contracts';
 import { SessionStaticKey } from '@nucypher/nucypher-core';
 import { ethers } from 'ethers';
 
+import { TtlCache } from '../../cache';
 import { Domain } from '../../porter';
 import { fromHexString } from '../../utils';
 import { SigningCoordinator__factory } from '../ethers-typechain';
@@ -14,21 +15,7 @@ export type SignerInfo = {
 };
 
 export class SigningCoordinatorAgent {
-  private static readonly CACHE_TTL_MS = 10_000;
-  private static cache = new Map<string, { data: unknown; expiry: number }>();
-
-  private static getCached<T>(key: string): T | undefined {
-    const entry = this.cache.get(key);
-    if (entry && Date.now() < entry.expiry) {
-      return entry.data as T;
-    }
-    this.cache.delete(key);
-    return undefined;
-  }
-
-  private static setCache(key: string, data: unknown): void {
-    this.cache.set(key, { data, expiry: Date.now() + this.CACHE_TTL_MS });
-  }
+  private static cache = new TtlCache(60_000);
 
   public static clearCache(): void {
     this.cache.clear();
@@ -40,7 +27,7 @@ export class SigningCoordinatorAgent {
     cohortId: number,
   ): Promise<SignerInfo[]> {
     const cacheKey = `participants:${domain}:${cohortId}`;
-    const cached = this.getCached<SignerInfo[]>(cacheKey);
+    const cached = this.cache.get<SignerInfo[]>(cacheKey);
     if (cached !== undefined) return cached;
 
     const coordinator = await this.connectReadOnly(provider, domain);
@@ -60,7 +47,7 @@ export class SigningCoordinatorAgent {
       },
     );
 
-    this.setCache(cacheKey, result);
+    this.cache.set(cacheKey, result);
     return result;
   }
 
@@ -70,14 +57,14 @@ export class SigningCoordinatorAgent {
     cohortId: number,
   ): Promise<number> {
     const cacheKey = `threshold:${domain}:${cohortId}`;
-    const cached = this.getCached<number>(cacheKey);
+    const cached = this.cache.get<number>(cacheKey);
     if (cached !== undefined) return cached;
 
     const coordinator = await this.connectReadOnly(provider, domain);
     const cohort = await coordinator.signingCohorts(cohortId);
     const result = cohort.threshold;
 
-    this.setCache(cacheKey, result);
+    this.cache.set(cacheKey, result);
     return result;
   }
 

--- a/packages/shared/test/signing-coordinator-cache.test.ts
+++ b/packages/shared/test/signing-coordinator-cache.test.ts
@@ -92,10 +92,10 @@ describe('SigningCoordinatorAgent cache', () => {
     expect(mockContract.signingCohorts).toHaveBeenCalledTimes(1);
   });
 
-  it('expires cache after 10 seconds', async () => {
+  it('expires cache after 60 seconds', async () => {
     await SigningCoordinatorAgent.getThreshold(mockProvider, domain, cohortId);
 
-    vi.advanceTimersByTime(10_001);
+    vi.advanceTimersByTime(60_001);
 
     await SigningCoordinatorAgent.getThreshold(mockProvider, domain, cohortId);
 

--- a/packages/shared/test/signing-coordinator-cache.test.ts
+++ b/packages/shared/test/signing-coordinator-cache.test.ts
@@ -1,0 +1,130 @@
+import { SessionStaticSecret } from '@nucypher/nucypher-core';
+import { initialize } from '@nucypher/shared';
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+
+import { SigningCoordinatorAgent } from '../src/contracts/agents/signing-coordinator';
+
+// We need to mock the private connectReadOnly method's dependencies
+// Mock getContract from nucypher-contracts and the factory
+vi.mock('@nucypher/nucypher-contracts', () => ({
+  getContract: vi.fn().mockReturnValue('0xMockContractAddress'),
+}));
+
+vi.mock('../src/contracts/ethers-typechain', () => ({
+  SigningCoordinator__factory: {
+    connect: vi.fn(),
+  },
+}));
+
+import { SigningCoordinator__factory } from '../src/contracts/ethers-typechain';
+
+describe('SigningCoordinatorAgent cache', () => {
+  const mockProvider = {
+    getNetwork: vi.fn(),
+  } as any;
+
+  const domain = 'lynx' as const;
+  const cohortId = 5;
+
+  let mockContract: any;
+
+  beforeAll(async () => {
+    await initialize();
+  });
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+
+    mockProvider.getNetwork.mockResolvedValue({ chainId: 11155111 });
+
+    const signerKey = SessionStaticSecret.random();
+    mockContract = {
+      getSigners: vi.fn().mockResolvedValue([
+        {
+          provider: '0xnode1',
+          signerAddress: '0x0000000000000000000000000000000000000001',
+          signingRequestStaticKey: `0x${Buffer.from(signerKey.publicKey().toBytes()).toString('hex')}`,
+        },
+      ]),
+      signingCohorts: vi.fn().mockResolvedValue({ threshold: 2 }),
+    };
+
+    vi.mocked(SigningCoordinator__factory.connect).mockReturnValue(
+      mockContract as any,
+    );
+
+    // Clear cache between tests
+    SigningCoordinatorAgent.clearCache();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('caches getParticipants for same domain and cohortId', async () => {
+    await SigningCoordinatorAgent.getParticipants(
+      mockProvider,
+      domain,
+      cohortId,
+    );
+    await SigningCoordinatorAgent.getParticipants(
+      mockProvider,
+      domain,
+      cohortId,
+    );
+
+    expect(mockContract.getSigners).toHaveBeenCalledTimes(1);
+  });
+
+  it('caches getThreshold for same domain and cohortId', async () => {
+    await SigningCoordinatorAgent.getThreshold(mockProvider, domain, cohortId);
+    await SigningCoordinatorAgent.getThreshold(mockProvider, domain, cohortId);
+
+    expect(mockContract.signingCohorts).toHaveBeenCalledTimes(1);
+  });
+
+  it('expires cache after 10 seconds', async () => {
+    await SigningCoordinatorAgent.getThreshold(mockProvider, domain, cohortId);
+
+    vi.advanceTimersByTime(10_001);
+
+    await SigningCoordinatorAgent.getThreshold(mockProvider, domain, cohortId);
+
+    expect(mockContract.signingCohorts).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not share cache across different cohortIds', async () => {
+    await SigningCoordinatorAgent.getThreshold(mockProvider, domain, 1);
+    await SigningCoordinatorAgent.getThreshold(mockProvider, domain, 2);
+
+    expect(mockContract.signingCohorts).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not share cache across different domains', async () => {
+    await SigningCoordinatorAgent.getThreshold(mockProvider, 'lynx', cohortId);
+    await SigningCoordinatorAgent.getThreshold(
+      mockProvider,
+      'mainnet',
+      cohortId,
+    );
+
+    expect(mockContract.signingCohorts).toHaveBeenCalledTimes(2);
+  });
+
+  it('clearCache forces fresh fetch', async () => {
+    await SigningCoordinatorAgent.getThreshold(mockProvider, domain, cohortId);
+    SigningCoordinatorAgent.clearCache();
+    await SigningCoordinatorAgent.getThreshold(mockProvider, domain, cohortId);
+
+    expect(mockContract.signingCohorts).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/shared/test/signing-coordinator-cache.test.ts
+++ b/packages/shared/test/signing-coordinator-cache.test.ts
@@ -11,6 +11,7 @@ import {
 } from 'vitest';
 
 import { SigningCoordinatorAgent } from '../src/contracts/agents/signing-coordinator';
+import { toHexString } from '../src/utils';
 
 // We need to mock the private connectReadOnly method's dependencies
 // Mock getContract from nucypher-contracts and the factory
@@ -51,7 +52,7 @@ describe('SigningCoordinatorAgent cache', () => {
         {
           provider: '0xnode1',
           signerAddress: '0x0000000000000000000000000000000000000001',
-          signingRequestStaticKey: `0x${Buffer.from(signerKey.publicKey().toBytes()).toString('hex')}`,
+          signingRequestStaticKey: `0x${toHexString(signerKey.publicKey().toBytes())}`,
         },
       ]),
       signingCohorts: vi.fn().mockResolvedValue({ threshold: 2 }),


### PR DESCRIPTION
Cache `getParticipants` and `getThreshold` with a 10s TTL to reduce redundant contract reads.