### PR TITLE
Canonical AA v0.7 Support

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@changesets/cli": "^2.28.1",
-    "@nucypher/nucypher-core": "^0.15.1-dev.3",
+    "@nucypher/nucypher-core": "^0.15.1-dev.4",
     "ethers": "^5.8.0"
   },
   "devDependencies": {
@@ -65,7 +65,7 @@
       ]
     },
     "overrides": {
-      "@nucypher/nucypher-core": "^0.15.1-dev.3",
+      "@nucypher/nucypher-core": "^0.15.1-dev.4",
       "glob-parent@<5.1.2": ">=5.1.2",
       "node-forge@<1.0.0": ">=1.0.0",
       "node-forge@<1.3.0": ">=1.3.0",

--- a/packages/pre/package.json
+++ b/packages/pre/package.json
@@ -38,7 +38,7 @@
     "typedoc": "typedoc"
   },
   "dependencies": {
-    "@nucypher/nucypher-core": "^0.15.1-dev.3",
+    "@nucypher/nucypher-core": "^0.15.1-dev.4",
     "@nucypher/shared": "workspace:*",
     "ethers": "^5.8.0"
   },

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -43,7 +43,7 @@
     "@ethersproject/abi": "^5.8.0",
     "@ethersproject/providers": "^5.8.0",
     "@nucypher/nucypher-contracts": "^0.26.0-alpha.3",
-    "@nucypher/nucypher-core": "^0.15.1-dev.3",
+    "@nucypher/nucypher-core": "^0.15.1-dev.4",
     "axios": "^1.13.5",
     "deep-equal": "^2.2.3",
     "ethers": "^5.8.0",

--- a/packages/taco/package.json
+++ b/packages/taco/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@astronautlabs/jsonpath": "^1.1.2",
-    "@nucypher/nucypher-core": "^0.15.1-dev.3",
+    "@nucypher/nucypher-core": "^0.15.1-dev.4",
     "@nucypher/shared": "workspace:*",
     "@nucypher/taco-auth": "workspace:*",
     "ethers": "^5.8.0",

--- a/packages/taco/src/index.ts
+++ b/packages/taco/src/index.ts
@@ -14,6 +14,7 @@ export {
 export * as conditions from './conditions';
 
 export {
+  AAVersion,
   SignResult,
   TacoSignature,
   setSigningCohortConditions,

--- a/packages/taco/src/sign.ts
+++ b/packages/taco/src/sign.ts
@@ -160,7 +160,7 @@ export async function signUserOp(
   cohortId: number,
   chainId: number,
   userOp: UserOperationToSign | PackedUserOperationToSign,
-  aaVersion: 'mdt' | '0.7.0' | '0.8.0' | string,
+  aaVersion: 'mdt' | '0.7.0' | '0.8.0',
   context?: ConditionContext,
   porterUris?: string[],
 ): Promise<SignResult> {

--- a/packages/taco/src/sign.ts
+++ b/packages/taco/src/sign.ts
@@ -50,6 +50,8 @@ export type SignResult = {
   signingResults: { [ursulaAddress: string]: TacoSignature };
 };
 
+export type AAVersion = '0.8.0' | 'mdt' | '0.7.0';
+
 function aggregateSignatures(
   signatures: TacoSignature[],
   threshold: number,
@@ -83,7 +85,7 @@ async function makeSigningRequests(
   chainId: number,
   signers: Array<SignerInfo>,
   userOp: UserOperationToSign | PackedUserOperationToSign,
-  aaVersion: string,
+  aaVersion: AAVersion,
   conditionContext?: ConditionContext,
 ): Promise<{
   sharedSecrets: Record<string, SessionSharedSecret>;
@@ -160,7 +162,7 @@ export async function signUserOp(
   cohortId: number,
   chainId: number,
   userOp: UserOperationToSign | PackedUserOperationToSign,
-  aaVersion: 'mdt' | '0.7.0' | '0.8.0',
+  aaVersion: AAVersion,
   context?: ConditionContext,
   porterUris?: string[],
 ): Promise<SignResult> {

--- a/packages/taco/src/sign.ts
+++ b/packages/taco/src/sign.ts
@@ -160,7 +160,7 @@ export async function signUserOp(
   cohortId: number,
   chainId: number,
   userOp: UserOperationToSign | PackedUserOperationToSign,
-  aaVersion: 'mdt' | '0.8.0' | string,
+  aaVersion: 'mdt' | '0.7.0' | '0.8.0' | string,
   context?: ConditionContext,
   porterUris?: string[],
 ): Promise<SignResult> {

--- a/packages/taco/test/taco-sign.test.ts
+++ b/packages/taco/test/taco-sign.test.ts
@@ -347,6 +347,8 @@ describe('TACo Signing', () => {
     const threshold = 2;
 
     it.each([
+      ['0.7.0', userOp],
+      ['0.7.0', packedUserOp],
       ['0.8.0', userOp],
       ['0.8.0', packedUserOp],
       ['mdt', userOp],
@@ -406,7 +408,10 @@ describe('TACo Signing', () => {
           threshold,
         );
 
-        const call = porterSignUserOpMock.mock.calls[porterSignUserOpMock.mock.calls.length - 1]!;
+        const call =
+          porterSignUserOpMock.mock.calls[
+            porterSignUserOpMock.mock.calls.length - 1
+          ]!;
         const [op] = call;
 
         const nodes = ['0xnode1', '0xnode2'];
@@ -483,7 +488,10 @@ describe('TACo Signing', () => {
         },
         threshold,
       );
-      const call = porterSignUserOpMock.mock.calls[porterSignUserOpMock.mock.calls.length - 1]!;
+      const call =
+        porterSignUserOpMock.mock.calls[
+          porterSignUserOpMock.mock.calls.length - 1
+        ]!;
       const [op] = call;
 
       const nodes = ['0xnode1', '0xnode2'];

--- a/packages/taco/test/taco-sign.test.ts
+++ b/packages/taco/test/taco-sign.test.ts
@@ -26,7 +26,7 @@ import { ContractCondition } from '../src/conditions/base/contract';
 import { RpcCondition } from '../src/conditions/base/rpc';
 import { CompoundCondition } from '../src/conditions/compound-condition';
 import { ConditionExpression } from '../src/conditions/condition-expr';
-import { setSigningCohortConditions, signUserOp } from '../src/sign';
+import { AAVersion, setSigningCohortConditions, signUserOp } from '../src/sign';
 
 import { mockMakeSessionKey } from './test-utils';
 
@@ -346,17 +346,20 @@ describe('TACo Signing', () => {
     const aaVersion = '0.8.0';
     const threshold = 2;
 
-    it.each([
+    const validAAVersionCases: Array<
+      [AAVersion, UserOperationToSign | PackedUserOperationToSign]
+    > = [
       ['0.7.0', userOp],
       ['0.7.0', packedUserOp],
       ['0.8.0', userOp],
       ['0.8.0', packedUserOp],
       ['mdt', userOp],
       ['mdt', packedUserOp],
-    ])(
+    ];
+    it.each(validAAVersionCases)(
       'should sign user operation and packed user operations for valid aa versions',
       async (
-        validAAVersion: string,
+        validAAVersion: AAVersion,
         userOp: UserOperationToSign | PackedUserOperationToSign,
       ) => {
         const encryptedResponses = {
@@ -395,7 +398,7 @@ describe('TACo Signing', () => {
           cohortId,
           chainId,
           userOp,
-          validAAVersion as 'mdt' | '0.7.0' | '0.8.0',
+          validAAVersion,
           undefined,
           porterUris,
         );

--- a/packages/taco/test/taco-sign.test.ts
+++ b/packages/taco/test/taco-sign.test.ts
@@ -395,7 +395,7 @@ describe('TACo Signing', () => {
           cohortId,
           chainId,
           userOp,
-          validAAVersion,
+          validAAVersion as 'mdt' | '0.7.0' | '0.8.0',
           undefined,
           porterUris,
         );

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -29,7 +29,7 @@
     "lint:fix": "pnpm lint --fix"
   },
   "dependencies": {
-    "@nucypher/nucypher-core": "^0.15.1-dev.3",
+    "@nucypher/nucypher-core": "^0.15.1-dev.4",
     "@nucypher/shared": "workspace:*",
     "@nucypher/taco-auth": "workspace:*",
     "axios": "^1.13.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@nucypher/nucypher-core': ^0.15.1-dev.3
+  '@nucypher/nucypher-core': ^0.15.1-dev.4
   glob-parent@<5.1.2: '>=5.1.2'
   node-forge@<1.0.0: '>=1.0.0'
   node-forge@<1.3.0: '>=1.3.0'
@@ -19,8 +19,8 @@ importers:
         specifier: ^2.28.1
         version: 2.29.5
       '@nucypher/nucypher-core':
-        specifier: ^0.15.1-dev.3
-        version: 0.15.1-dev.3
+        specifier: ^0.15.1-dev.4
+        version: 0.15.1-dev.4
       ethers:
         specifier: ^5.8.0
         version: 5.8.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
@@ -491,8 +491,8 @@ importers:
   packages/pre:
     dependencies:
       '@nucypher/nucypher-core':
-        specifier: ^0.15.1-dev.3
-        version: 0.15.1-dev.3
+        specifier: ^0.15.1-dev.4
+        version: 0.15.1-dev.4
       '@nucypher/shared':
         specifier: workspace:*
         version: link:../shared
@@ -516,8 +516,8 @@ importers:
         specifier: ^0.26.0-alpha.3
         version: 0.26.0-alpha.3
       '@nucypher/nucypher-core':
-        specifier: ^0.15.1-dev.3
-        version: 0.15.1-dev.3
+        specifier: ^0.15.1-dev.4
+        version: 0.15.1-dev.4
       axios:
         specifier: ^1.13.5
         version: 1.15.0
@@ -565,8 +565,8 @@ importers:
         specifier: ^1.1.2
         version: 1.1.2
       '@nucypher/nucypher-core':
-        specifier: ^0.15.1-dev.3
-        version: 0.15.1-dev.3
+        specifier: ^0.15.1-dev.4
+        version: 0.15.1-dev.4
       '@nucypher/shared':
         specifier: workspace:*
         version: link:../shared
@@ -627,8 +627,8 @@ importers:
   packages/test-utils:
     dependencies:
       '@nucypher/nucypher-core':
-        specifier: ^0.15.1-dev.3
-        version: 0.15.1-dev.3
+        specifier: ^0.15.1-dev.4
+        version: 0.15.1-dev.4
       '@nucypher/shared':
         specifier: workspace:*
         version: link:../shared
@@ -2558,8 +2558,8 @@ packages:
   '@nucypher/nucypher-contracts@0.26.0-alpha.3':
     resolution: {integrity: sha512-BQSDTl+E77JHS0ck79vyGQTPjTFZieWaKY1nSAghQGTS3drOU21loqe9v6221zlycU6T1cZ4c3ffGXW3qc37ng==}
 
-  '@nucypher/nucypher-core@0.15.1-dev.3':
-    resolution: {integrity: sha512-0MJ8XvH2X5OyEx+f2i9A2iA+KosHzxZbOt8V3Ye6ZDlMC5N4aeDOEJ02ftwnc0C0NO0CPqTuLlYGbrreW57K+w==}
+  '@nucypher/nucypher-core@0.15.1-dev.4':
+    resolution: {integrity: sha512-PQvWV7jsa8LSaYaCCIujebVAx897W2t77cfKw5/Gn6hIiFqm6Idw6QZl2SnSND09ZuuPM/eH/s1jJgaFVGUwWQ==}
 
   '@nucypher/shared@0.5.0':
     resolution: {integrity: sha512-Y+0oEgVtoud4BP/pvj2elPm5igrQ8AAUwYYmUiLpXNqQMRF4zFnYaGbl+xhKk45CYG8S9cDKJEN8nopzVADTNw==}
@@ -12151,14 +12151,14 @@ snapshots:
 
   '@nucypher/nucypher-contracts@0.26.0-alpha.3': {}
 
-  '@nucypher/nucypher-core@0.15.1-dev.3': {}
+  '@nucypher/nucypher-core@0.15.1-dev.4': {}
 
   '@nucypher/shared@0.5.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)':
     dependencies:
       '@ethersproject/abi': 5.8.0
       '@ethersproject/providers': 5.8.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       '@nucypher/nucypher-contracts': 0.25.0
-      '@nucypher/nucypher-core': 0.15.1-dev.3
+      '@nucypher/nucypher-core': 0.15.1-dev.4
       axios: 1.15.0
       deep-equal: 2.2.3
       ethers: 5.8.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
@@ -12184,7 +12184,7 @@ snapshots:
   '@nucypher/taco@0.6.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)':
     dependencies:
       '@astronautlabs/jsonpath': 1.1.2
-      '@nucypher/nucypher-core': 0.15.1-dev.3
+      '@nucypher/nucypher-core': 0.15.1-dev.4
       '@nucypher/shared': 0.5.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       '@nucypher/taco-auth': 0.3.0(bufferutil@4.0.9)(ethers@5.8.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(utf-8-validate@5.0.10)
       ethers: 5.8.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)


### PR DESCRIPTION
**Type of PR:**

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [x] Other

**Required reviews:**

- [ ] 1
- [x] 2
- [ ] 3

**What this does:**
Reopened from #776 and targeted for `epic-v0.7.x`.

- Depends on https://github.com/nucypher/nucypher-core/pull/130
- Requires nodes to run https://github.com/nucypher/nucypher/pull/3727

_from CoPilot:_
- Bump @nucypher/nucypher-core from 0.15.1-dev.3 to 0.15.1-dev.4 across root/workspace dependencies and lockfile.
- Extend TACo signing tests to cover AA version 0.7.0 (for both UserOp and PackedUserOp).
- Update signUserOp TypeScript signature to accept aaVersion: 'mdt' | '0.7.0' | '0.8.0'.

**Issues fixed/closed:**

> - Fixes #...

**Why it's needed:**

> Explain how this PR fits in the greater context of the NuCypher Network. E.g.,
> if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**

> What should reviewers focus on? Is there a particular commit/function/section
> of your PR that requires more attention from reviewers?
