### PR TITLE
docs: add validate-conditions.ts script

### DIFF
--- a/packages/taco/scripts/validate-conditions.ts
+++ b/packages/taco/scripts/validate-conditions.ts
@@ -1,0 +1,45 @@
+#!/usr/bin/env npx tsx
+/**
+ * Validates conditions.json against the TACo SDK schemas
+ * This helps identify client-side validation errors vs server-side errors
+ *
+ * Usage: tsx scripts/validate-conditions.ts [path/to/conditions.json]
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { ConditionExpression } from '../src/conditions/condition-expr';
+
+async function main() {
+  const conditionsPath = path.resolve(process.argv[2] ?? 'conditions.json');
+  console.log(`Loading conditions from: ${conditionsPath}`);
+
+  const conditionsJson = fs.readFileSync(conditionsPath, 'utf-8');
+  const conditionsObj = JSON.parse(conditionsJson);
+
+  console.log('\nConditions loaded:');
+  console.log(JSON.stringify(conditionsObj, null, 2));
+
+  console.log('\n--- Validating with TACo SDK ---\n');
+
+  try {
+    const expr = ConditionExpression.fromObj(conditionsObj);
+    console.log('✅ Conditions are VALID according to TACo SDK!');
+    console.log('\nParsed condition type:', expr.condition.conditionType);
+  } catch (error) {
+    console.error('❌ Conditions are INVALID according to TACo SDK!');
+    // Write full error to file
+    const errorStr = error instanceof Error
+      ? `${error.name}: ${error.message}\n\nStack: ${error.stack}`
+      : JSON.stringify(error, null, 2);
+    const errorPath = `${conditionsPath}.error.txt`;
+    fs.writeFileSync(errorPath, errorStr);
+    console.error(`\nFull error written to: ${errorPath}`);
+    console.error('\nError message:', error instanceof Error ? error.message : String(error));
+
+    process.exit(1);
+  }
+}
+
+main().catch(console.error);


### PR DESCRIPTION
## Summary
Adds `packages/taco/scripts/validate-conditions.ts`: a CLI helper that runs a `conditions.json` file through `ConditionExpression.fromObj` and reports whether it satisfies the SDK's Zod schemas.

Hosting the script alongside the schemas it validates lets the [TACo docs "Validating Conditions" page](https://github.com/nucypher/taco-docs/blob/main/for-developers/taco-sdk/references/conditions/validating-conditions.md) link to canonical infrastructure instead of an unrelated repo.

## Context
Requested in @derekpierre's review on nucypher/taco-docs#12: *"If the script is tested and works well, you can add it to the `nucypher/taco-web` repos. Once this URL is fixed, I can approve."*

The script was previously hosted at [`theref/discord-taco-web/scripts/validate-conditions.ts`](https://github.com/theref/discord-taco-web/blob/main/scripts/validate-conditions.ts).

## Behaviour
- Optional CLI arg for the conditions file path; defaults to `./conditions.json`.
- Exits 0 with the parsed `conditionType` on success.
- Exits 1 on invalid input and writes the full Zod error to `<input>.error.txt` (intended for pasting into an LLM prompt for diagnosis).

## Follow-up
Once this lands, `validating-conditions.md` in `nucypher/taco-docs` will be updated to point at the canonical script in this repo.

## Test plan
- [ ] `pnpm tsx packages/taco/scripts/validate-conditions.ts <valid.json>` → prints the parsed condition type, exits 0.
- [ ] `pnpm tsx packages/taco/scripts/validate-conditions.ts <invalid.json>` → prints the Zod error, writes `<invalid.json>.error.txt`, exits 1.